### PR TITLE
Fix IndexTTS2 Mandarin tokenization and punctuation crashes

### DIFF
--- a/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
@@ -14,6 +14,8 @@ public struct IndexTTS2Token: Equatable, Sendable {
 public enum IndexTTS2TokenizerError: Error, LocalizedError, Equatable {
     case emptyVocabulary
     case textTooLong(maxScalars: Int)
+    /// Only thrown for models without an `<unk>` piece; the published
+    /// `bpe.model` has one, so unsupported scalars degrade to it instead.
     case unencodableText(String)
 
     public var errorDescription: String? {
@@ -28,16 +30,37 @@ public enum IndexTTS2TokenizerError: Error, LocalizedError, Equatable {
     }
 }
 
-/// SentencePiece tokenizer scaffold for IndexTTS2's `bpe.model`.
+/// SentencePiece Unigram tokenizer for IndexTTS2's `bpe.model`.
 ///
-/// Upstream applies additional Chinese text normalization before SentencePiece.
-/// This Swift port starts with the model-compatible Unigram Viterbi path and
-/// mirrors the upstream Latin uppercasing used before BPE lookup.
+/// Mirrors the upstream text front end (`indextts/utils/front.py`) ahead of
+/// the SentencePiece lattice:
+///
+/// 1. `char_rep_map` punctuation rewriting (`。` → `.`, `，` → `,`, quotes and
+///    brackets → `'`, `:`/`;` → `,`, …). The vocabulary has pieces for none
+///    of the originals.
+/// 2. `tokenize_by_CJK_char`: a word boundary before every CJK scalar, so the
+///    lattice emits a standalone `▁` ahead of each character — the shape the
+///    GPT was trained on. The vocabulary has no `▁`-prefixed CJK pieces.
+/// 3. Uppercasing of the non-CJK text.
+///
+/// Scalars without a piece become `<unk>`, with consecutive runs merged, as
+/// SentencePiece does. Upstream additionally runs a number and glossary
+/// normalizer (WeTextProcessing) before this point; this port does not, so
+/// digit runs degrade to `<unk>` and numbers should be written out as words.
 public struct IndexTTS2Tokenizer: Sendable {
     public static let maxInputScalars = 2_048
 
+    /// SentencePiece's `kUnkPenalty`: `<unk>` nodes score `minScore - 10`.
+    private static let unknownPenalty: Float = 10
+
     private let pieces: [SentencePieceModel.Piece]
     private let tokenToId: [String: Int]
+    private let singleScalarPieces: Set<Unicode.Scalar>
+    private let maxPieceScalars: Int
+    private let unknownScore: Float
+
+    /// Id of the `<unk>` piece, or nil when the model has none.
+    public let unknownTokenId: Int?
 
     public init(modelURL: URL) throws {
         let model = try SentencePieceModel(contentsOf: modelURL)
@@ -52,6 +75,14 @@ public struct IndexTTS2Tokenizer: Sendable {
         self.tokenToId = Dictionary(
             uniqueKeysWithValues: pieces.enumerated().map { ($0.element.text, $0.offset) }
         )
+        let lattice = pieces.filter { !$0.isControlOrUnknown }
+        self.singleScalarPieces = Set(lattice.compactMap { piece in
+            let scalars = piece.text.unicodeScalars
+            return scalars.count == 1 ? scalars.first : nil
+        })
+        self.maxPieceScalars = lattice.map { $0.text.unicodeScalars.count }.max() ?? 1
+        self.unknownScore = (lattice.map(\.score).min() ?? 0) - Self.unknownPenalty
+        self.unknownTokenId = pieces.firstIndex { $0.pieceType == .unknown }
     }
 
     public func tokenize(_ text: String) throws -> [IndexTTS2Token] {
@@ -74,7 +105,7 @@ public struct IndexTTS2Tokenizer: Sendable {
         bestScores[0] = 0
 
         for start in 0..<scalars.count where bestScores[start].isFinite {
-            for end in (start + 1)...scalars.count {
+            for end in (start + 1)...min(scalars.count, start + maxPieceScalars) {
                 let piece = String(String.UnicodeScalarView(scalars[start..<end]))
                 guard let id = tokenToId[piece] else { continue }
                 guard !pieces[id].isControlOrUnknown else { continue }
@@ -83,6 +114,16 @@ public struct IndexTTS2Tokenizer: Sendable {
                 if score > bestScores[end] || (score == bestScores[end] && isTieBreakBetter(id, start, than: backPointer[end])) {
                     bestScores[end] = score
                     backPointer[end] = (start, id)
+                }
+            }
+
+            // SentencePiece adds a one-scalar `<unk>` node wherever no
+            // single-scalar piece covers the position.
+            if let unknownTokenId, !singleScalarPieces.contains(scalars[start]) {
+                let score = bestScores[start] + unknownScore
+                if score > bestScores[start + 1] {
+                    bestScores[start + 1] = score
+                    backPointer[start + 1] = (start, unknownTokenId)
                 }
             }
         }
@@ -94,32 +135,144 @@ public struct IndexTTS2Tokenizer: Sendable {
         var ids: [Int] = []
         var cursor = scalars.count
         while cursor > 0, let pointer = backPointer[cursor] {
-            ids.append(pointer.id)
+            // Consecutive `<unk>` nodes collapse into one, as in SentencePiece.
+            if pointer.id != unknownTokenId || ids.last != unknownTokenId {
+                ids.append(pointer.id)
+            }
             cursor = pointer.start
         }
-        return ids.reversed()
+        ids.reverse()
+
+        if let unknownTokenId {
+            let unknownCount = ids.filter { $0 == unknownTokenId }.count
+            if unknownCount > 0 {
+                AudioLog.inference.warning(
+                    "IndexTTS2 tokenizer mapped \(unknownCount) span(s) to <unk>; digits and unsupported symbols have no vocabulary pieces, write numbers as words.")
+            }
+        }
+        return ids
     }
 
+    /// Joins pieces back into text, undoing the per-character CJK spacing.
+    /// Spaces stay between Latin words and are dropped next to CJK scalars.
     public func decode(_ ids: [Int]) -> String {
-        ids.compactMap { id in
+        let surface = ids.compactMap { id -> String? in
             guard id >= 0, id < pieces.count else { return nil }
             let piece = pieces[id]
             return piece.isControlOrUnknown ? nil : piece.text
         }
         .joined()
         .replacingOccurrences(of: "▁", with: " ")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let scalars = Array(surface.unicodeScalars)
+        var output = String.UnicodeScalarView()
+        for (index, scalar) in scalars.enumerated() {
+            if scalar == " ",
+               let previous = output.last,
+               let next = scalars[(index + 1)...].first(where: { $0 != " " }),
+               Self.isCJK(previous) || Self.isCJK(next),
+               !Self.isLatinAlphanumeric(previous), !Self.isLatinAlphanumeric(next) {
+                continue
+            }
+            output.append(scalar)
+        }
+        return String(output).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    // MARK: - Upstream text front end
+
     private func normalizedPieceText(for text: String) -> String {
-        let normalized = (text as NSString)
+        let rewritten = Self.rewritePunctuation(in: text)
+        let spaced = Self.separateCJKCharacters(in: rewritten).uppercased()
+        let normalized = (spaced as NSString)
             .precomposedStringWithCompatibilityMapping
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(whereSeparator: { $0.isWhitespace })
             .joined(separator: " ")
-            .uppercased()
         guard !normalized.isEmpty else { return "" }
         return "▁" + normalized.replacingOccurrences(of: " ", with: "▁")
+    }
+
+    private struct Rewrite: Sendable {
+        let from: [Unicode.Scalar]
+        let to: [Unicode.Scalar]
+
+        init(_ from: String, _ to: String) {
+            self.from = Array(from.unicodeScalars)
+            self.to = Array(to.unicodeScalars)
+        }
+    }
+
+    /// Upstream `char_rep_map`, in its original order: entries are tried in
+    /// sequence at each position and the first match wins, which is how the
+    /// upstream regex alternation behaves.
+    private static let punctuationRewrites: [Rewrite] = [
+        Rewrite("：", ","), Rewrite("；", ","), Rewrite(";", ","), Rewrite("，", ","), Rewrite("。", "."),
+        Rewrite("！", "!"), Rewrite("？", "?"), Rewrite("\n", " "), Rewrite("·", "-"), Rewrite("、", ","),
+        Rewrite("...", "…"), Rewrite(",,,", "…"), Rewrite("，，，", "…"), Rewrite("……", "…"),
+        Rewrite("“", "'"), Rewrite("”", "'"), Rewrite("\"", "'"), Rewrite("‘", "'"), Rewrite("’", "'"),
+        Rewrite("（", "'"), Rewrite("）", "'"), Rewrite("(", "'"), Rewrite(")", "'"),
+        Rewrite("《", "'"), Rewrite("》", "'"), Rewrite("【", "'"), Rewrite("】", "'"),
+        Rewrite("[", "'"), Rewrite("]", "'"), Rewrite("—", "-"), Rewrite("～", "-"), Rewrite("~", "-"),
+        Rewrite("「", "'"), Rewrite("」", "'"), Rewrite(":", ","),
+    ]
+
+    /// Upstream `zh_char_rep_map`: the Chinese path additionally reads `$` as `.`.
+    private static let chinesePunctuationRewrites: [Rewrite] = [Rewrite("$", ".")] + punctuationRewrites
+
+    private static func rewritePunctuation(in text: String) -> String {
+        let scalars = Array(text.unicodeScalars)
+        let rules = usesChineseFrontEnd(scalars) ? chinesePunctuationRewrites : punctuationRewrites
+        var output = String.UnicodeScalarView()
+        var index = 0
+        while index < scalars.count {
+            if let rule = rules.first(where: { scalars[index...].starts(with: $0.from) }) {
+                output.append(contentsOf: rule.to)
+                index += rule.from.count
+            } else {
+                output.append(scalars[index])
+                index += 1
+            }
+        }
+        return String(output)
+    }
+
+    /// Upstream `use_chinese`: Han text, or text with no Latin letters at all.
+    private static func usesChineseFrontEnd(_ scalars: [Unicode.Scalar]) -> Bool {
+        let hasHan = scalars.contains { (0x4E00...0x9FFF).contains($0.value) }
+        let hasLatinLetter = scalars.contains { (0x41...0x5A).contains($0.value) || (0x61...0x7A).contains($0.value) }
+        return hasHan || !hasLatinLetter
+    }
+
+    /// Upstream `tokenize_by_CJK_char`: every CJK scalar becomes its own
+    /// whitespace-delimited word.
+    private static func separateCJKCharacters(in text: String) -> String {
+        var output = String.UnicodeScalarView()
+        for scalar in text.unicodeScalars {
+            if isCJK(scalar) {
+                output.append(" ")
+                output.append(scalar)
+                output.append(" ")
+            } else {
+                output.append(scalar)
+            }
+        }
+        return String(output)
+    }
+
+    /// The CJK ranges upstream splits on (`CJK_RANGE_PATTERN`).
+    private static func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x1100...0x11FF, 0x2E80...0xA4CF, 0xA840...0xD7AF, 0xF900...0xFAFF,
+             0xFE30...0xFE4F, 0xFF65...0xFFDC, 0x20000...0x2FFFF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isLatinAlphanumeric(_ scalar: Unicode.Scalar) -> Bool {
+        (0x30...0x39).contains(scalar.value) || (0x41...0x5A).contains(scalar.value) || (0x61...0x7A).contains(scalar.value)
     }
 
     private func isTieBreakBetter(

--- a/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
+++ b/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
@@ -202,15 +202,22 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
         let asrModelId = env["INDEXTTS2_E2E_ASR_MODEL"] ?? Self.defaultQwenASRModelId
         let asr = try await Qwen3ASRModel.fromPretrained(modelId: asrModelId)
         let asrStart = CFAbsoluteTimeGetCurrent()
-        let transcript = asr.transcribe(audio: audio, sampleRate: model.sampleRate, language: "english")
+        let language = env["INDEXTTS2_E2E_LANGUAGE"] ?? "english"
+        let transcript = asr.transcribe(audio: audio, sampleRate: model.sampleRate, language: language)
         let asrSec = CFAbsoluteTimeGetCurrent() - asrStart
         let asrRTF = asrSec / max(audioSec, 1e-6)
-        let wer = Self.wordErrorRate(reference: text, hypothesis: transcript)
+        // CJK references carry no word boundaries; score them per character.
+        let usesCharacters = text.unicodeScalars.contains(where: Self.isCJK)
+        let wer = usesCharacters
+            ? Self.characterErrorRate(reference: text, hypothesis: transcript)
+            : Self.wordErrorRate(reference: text, hypothesis: transcript)
         let maxWER = Double(env["INDEXTTS2_E2E_MAX_WER"] ?? "") ?? 0.25
 
         print(String(format:
-            "[IndexTTS2Roundtrip] asrModel=%@ transcript=\"%@\" wer=%.3f asrSec=%.3f asrRTF=%.3f maxWER=%.3f",
+            "[IndexTTS2Roundtrip] asrModel=%@ language=%@ metric=%@ transcript=\"%@\" wer=%.3f asrSec=%.3f asrRTF=%.3f maxWER=%.3f",
             asrModelId,
+            language,
+            usesCharacters ? "cer" : "wer",
             transcript,
             wer,
             asrSec,
@@ -419,8 +426,14 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
     }
 
     private static func wordErrorRate(reference: String, hypothesis: String) -> Double {
-        let ref = normalizedWords(reference)
-        let hyp = normalizedWords(hypothesis)
+        editRate(reference: normalizedWords(reference), hypothesis: normalizedWords(hypothesis))
+    }
+
+    private static func characterErrorRate(reference: String, hypothesis: String) -> Double {
+        editRate(reference: normalizedCharacters(reference), hypothesis: normalizedCharacters(hypothesis))
+    }
+
+    private static func editRate(reference ref: [String], hypothesis hyp: [String]) -> Double {
         guard !ref.isEmpty else { return hyp.isEmpty ? 0 : 1 }
 
         var previous = Array(0...hyp.count)
@@ -435,6 +448,16 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
             previous = current
         }
         return Double(previous[hyp.count]) / Double(ref.count)
+    }
+
+    private static func normalizedCharacters(_ text: String) -> [String] {
+        normalizedWords(text).flatMap { $0.map(String.init) }
+    }
+
+    private static func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+        (0x2E80...0x9FFF).contains(scalar.value)
+            || (0xF900...0xFAFF).contains(scalar.value)
+            || (0x20000...0x2FFFF).contains(scalar.value)
     }
 
     private static func normalizedWords(_ text: String) -> [String] {

--- a/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
+++ b/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
@@ -221,6 +221,45 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
         XCTAssertLessThanOrEqual(wer, maxWER, "ASR roundtrip WER exceeded threshold")
     }
 
+    func testTokenizerMatchesUpstreamTokenIDs() async throws {
+        let tokenizer = try await loadTokenizer()
+
+        // Golden ids from the upstream text front end (`char_rep_map` +
+        // `tokenize_by_CJK_char`) and SentencePiece on the published `bpe.model`.
+        let cases: [(text: String, ids: [Int])] = [
+            ("你好世界", [10201, 208, 10201, 1260, 10201, 22, 10201, 3755]),
+            ("你好，这是一个中文合成测试。",
+             [10201, 208, 10201, 1260, 10202, 10201, 5935, 10201, 2474, 10201, 7, 10201, 34, 10201, 36,
+              10201, 2398, 10201, 680, 10201, 2043, 10201, 3110, 10201, 5551, 10203]),
+            ("你好世界是 hello world 的中文",
+             [10201, 208, 10201, 1260, 10201, 22, 10201, 3755, 10201, 2474, 11122, 10394, 10201, 3880,
+              10201, 36, 10201, 2398]),
+            ("你好！吗？", [10201, 208, 10201, 1260, 10201, 10481, 10201, 694, 10219]),
+            ("Hello \"world\" (ok): done.",
+             [11122, 10201, 10206, 10603, 10391, 10438, 10258, 10206, 10201, 10206, 11412, 10206,
+              10209, 10467, 10216]),
+            ("你好🙂", [10201, 208, 10201, 1260, 10201, 2]),
+            ("A2024B", [10210, 2, 10445]),
+            ("今天是2024年", [10201, 124, 10201, 1221, 10201, 2474, 10201, 2, 10201, 1698]),
+        ]
+        for (text, ids) in cases {
+            XCTAssertEqual(try tokenizer.encode(text), ids, "token ids for \(text)")
+        }
+    }
+
+    private func loadTokenizer() async throws -> IndexTTS2Tokenizer {
+        let env = ProcessInfo.processInfo.environment
+        if let path = env["INDEXTTS2_E2E_BPE_MODEL"], !path.isEmpty {
+            let url = URL(fileURLWithPath: path)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw XCTSkip("INDEXTTS2_E2E_BPE_MODEL not found at \(url.path)")
+            }
+            return try IndexTTS2Tokenizer(modelURL: url)
+        }
+        let model = try await loadModel()
+        return try XCTUnwrap(model.tokenizer, "bundle tokenizer failed to initialize")
+    }
+
     private func loadModel() async throws -> IndexTTS2TTSModel {
         let env = ProcessInfo.processInfo.environment
         if let bundlePath = env["INDEXTTS2_E2E_BUNDLE"], !bundlePath.isEmpty {

--- a/Tests/IndexTTS2TTSTests/IndexTTS2TTSTests.swift
+++ b/Tests/IndexTTS2TTSTests/IndexTTS2TTSTests.swift
@@ -120,6 +120,98 @@ final class IndexTTS2TTSTests: XCTestCase {
         XCTAssertEqual(tokenizer.decode(ids), "HELLO WORLD")
     }
 
+    // MARK: - Tokenizer parity with the upstream IndexTTS2 text front end
+    //
+    // Upstream (`indextts/utils/front.py`) rewrites punctuation through
+    // `char_rep_map`, then `tokenize_by_CJK_char` puts a space before every
+    // CJK scalar and uppercases the rest before SentencePiece. The published
+    // `bpe.model` has no `▁`-prefixed CJK pieces, no digits, and none of
+    // `"`, `(`, `)`, `:`, `;`, `。`, `、`. Text that skips that front end
+    // either tokenizes differently from what the GPT was trained on or has
+    // no lattice path at all. Golden ids below come from upstream
+    // SentencePiece on a synthetic vocabulary that mirrors that layout.
+
+    func testIndexTTS2TokenizerSeparatesEveryCJKCharacter() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        // Upstream: ▁ 你 ▁ 好 ▁ 世 ▁ 界 — a standalone `▁` before each character.
+        XCTAssertEqual(try tokenizer.encode("你好世界"), [3, 4, 3, 5, 3, 6, 3, 7])
+    }
+
+    func testIndexTTS2TokenizerNormalizesCJKPunctuation() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        // `，` → `,` and `。` → `.`; `。` has no piece and used to throw `unencodableText`.
+        let ids = try tokenizer.encode("你好，这是一个中文合成测试。")
+        XCTAssertEqual(ids, [3, 4, 3, 5, 39, 3, 12, 3, 8, 3, 13, 3, 14, 3, 10, 3, 11, 3, 15, 3, 16, 3, 17, 3, 18, 40])
+        XCTAssertEqual(tokenizer.decode(ids), "你好,这是一个中文合成测试.")
+        XCTAssertEqual(try tokenizer.encode("你好！吗？"), [3, 4, 3, 5, 3, 36, 3, 22, 41])
+    }
+
+    func testIndexTTS2TokenizerHandlesMixedMandarinAndEnglish() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        let ids = try tokenizer.encode("你好世界是 hello world 的中文")
+        XCTAssertEqual(ids, [3, 4, 3, 5, 3, 6, 3, 7, 3, 8, 23, 24, 3, 9, 3, 10, 3, 11])
+        // Decoding drops the per-character spacing but keeps Latin word gaps.
+        XCTAssertEqual(tokenizer.decode(ids), "你好世界是 HELLO WORLD 的中文")
+    }
+
+    func testIndexTTS2TokenizerNormalizesLatinPunctuation() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        // `"`, `(`, `)` → `'` and `:` → `,`; none of the originals have pieces.
+        XCTAssertEqual(
+            try tokenizer.encode("Hello \"world\" (ok): done."),
+            [23, 3, 38, 26, 38, 3, 38, 28, 38, 34, 29, 35])
+        // Plain English is untouched by the front end.
+        XCTAssertEqual(try tokenizer.encode("Hello world."), [23, 24, 35])
+    }
+
+    func testIndexTTS2TokenizerEmitsSingleUnknownForUnsupportedScalars() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        // SentencePiece emits `<unk>` for uncovered scalars and merges runs.
+        XCTAssertEqual(try tokenizer.encode("你好🙂"), [3, 4, 3, 5, 3, 2])
+        XCTAssertEqual(try tokenizer.encode("A2024B"), [31, 2, 33])
+    }
+
+    func testIndexTTS2TokenizerTreatsDigitRunsAsUnknown() throws {
+        let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
+
+        // The vocabulary has no digit pieces; upstream expands numbers with a
+        // text normalizer this port does not have yet, so a digit run must
+        // degrade to one `<unk>` rather than reject the whole input.
+        XCTAssertEqual(try tokenizer.encode("今天是2024年"), [3, 19, 3, 20, 3, 8, 3, 2, 3, 21])
+    }
+
+    /// Mirrors the published `bpe.model` layout: `<s>`/`</s>`/`<unk>` at
+    /// ids 0–2, a standalone `▁`, bare user-defined CJK scalars with score 0
+    /// (no `▁`-prefixed CJK pieces), uppercase Latin pieces, and ASCII
+    /// punctuation only — no digits and none of `"`, `(`, `)`, `:`, `;`, `。`.
+    private static let mandarinPieces: [SentencePieceModel.Piece] = {
+        func piece(
+            _ text: String, _ score: Float, _ type: SentencePieceModel.PieceType = .normal
+        ) -> SentencePieceModel.Piece {
+            SentencePieceModel.Piece(text: text, score: score, type: type.rawValue)
+        }
+        var pieces = [
+            piece("<s>", 0, .control),
+            piece("</s>", 0, .control),
+            piece("<unk>", 0, .unknown),
+            piece("▁", -0.28),
+        ]
+        pieces += "你好世界是的中文这一个合成测试今天年吗".map { piece(String($0), 0, .userDefined) }
+        pieces += [
+            piece("▁HELLO", -1), piece("▁WORLD", -1), piece("HELLO", -5), piece("WORLD", -5),
+            piece("▁OK", -2), piece("OK", -4), piece("▁DONE", -2), piece("DONE", -4),
+            piece("▁A", -3), piece("A", -6), piece("B", -6),
+            piece(",", -5.57), piece(".", -5.98), piece("!", -9.56), piece("?", -7.77), piece("'", -5.33),
+            piece("▁,", -3.28), piece("▁.", -4.06), piece("▁?", -6.21), piece("...", -8), piece("-", -11.47),
+        ]
+        return pieces
+    }()
+
     func testIndexTTS2EmotionPresetVectors() throws {
         let eager = try IndexTTS2EmotionControl(preset: .eager, weight: 0.5)
 

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -130,7 +130,9 @@ Useful diagnostic overrides are `INDEXTTS2_E2E_SEED`,
 `INDEXTTS2_E2E_EMOTION`, `INDEXTTS2_E2E_EMOTION_WEIGHT`,
 `INDEXTTS2_E2E_SPEAKING_RATE`, `INDEXTTS2_E2E_MAX_PAUSE`,
 `INDEXTTS2_E2E_SEMANTIC_CODES`, `INDEXTTS2_E2E_SEMANTIC_ONLY=1`, and
-`INDEXTTS2_E2E_SEED_SWEEP=0-20`.
+`INDEXTTS2_E2E_SEED_SWEEP=0-20`. `INDEXTTS2_E2E_LANGUAGE=zh` with a Mandarin
+`INDEXTTS2_E2E_TEXT` runs the round trip in Chinese; CJK references are scored
+by character error rate instead of WER.
 
 `testTokenizerMatchesUpstreamTokenIDs` pins the native tokenizer to golden
 token ids from the upstream text front end (`char_rep_map` +

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -37,6 +37,12 @@ For identity-first cloning, omit explicit emotion control and use
 `IndexTTS2SynthesisOptions` for tempo and pause shaping. High emotion weights can
 reduce speaker similarity.
 
+The tokenizer mirrors the upstream text front end: CJK punctuation is rewritten
+(`。` → `.`), every CJK character gets its own word boundary, and Latin text is
+uppercased, so Mandarin and mixed Chinese/English input work as-is. The
+vocabulary has no digit pieces and there is no number normalizer yet, so write
+numbers as words (`二零二四年`, `twenty twenty-four`); digit runs become `<unk>`.
+
 ## CLI
 
 Use a local exported bundle:
@@ -125,3 +131,10 @@ Useful diagnostic overrides are `INDEXTTS2_E2E_SEED`,
 `INDEXTTS2_E2E_SPEAKING_RATE`, `INDEXTTS2_E2E_MAX_PAUSE`,
 `INDEXTTS2_E2E_SEMANTIC_CODES`, `INDEXTTS2_E2E_SEMANTIC_ONLY=1`, and
 `INDEXTTS2_E2E_SEED_SWEEP=0-20`.
+
+`testTokenizerMatchesUpstreamTokenIDs` pins the native tokenizer to golden
+token ids from the upstream text front end (`char_rep_map` +
+`tokenize_by_CJK_char` + SentencePiece) for Mandarin, mixed-script,
+punctuation, and unknown-scalar inputs. It only needs `bpe.model`, so
+`INDEXTTS2_E2E_BPE_MODEL=/path/to/bpe.model` runs it without loading the
+full bundle.

--- a/docs/models/indextts2.md
+++ b/docs/models/indextts2.md
@@ -71,9 +71,13 @@ sums the matching emotion rows by vector weight, and keeps the remaining weight
 on the reference emotion.
 
 `IndexTTS2Tokenizer` provides a native SentencePiece Unigram path for the
-published `bpe.model`. It mirrors upstream Latin uppercasing before BPE and uses
-the model-compatible Viterbi tokenization path. Full parity still needs upstream
-Chinese normalization and glossary handling.
+published `bpe.model` and mirrors the upstream text front end ahead of it:
+`char_rep_map` punctuation rewriting (`。` → `.`, quotes and brackets → `'`),
+a word boundary before every CJK character so the lattice emits a standalone
+`▁` ahead of each one, and Latin uppercasing. Scalars without a piece become
+`<unk>` with runs merged, as in SentencePiece. The vocabulary has no digit
+pieces and the port has no number or glossary normalizer (upstream uses
+WeTextProcessing), so digit runs degrade to `<unk>`; write numbers as words.
 
 ## Validation Status
 
@@ -85,7 +89,8 @@ treating this port as benchmark-grade.
 
 ## Remaining Work
 
-- Chinese normalizer parity.
+- Number and glossary normalization (upstream WeTextProcessing); digit runs
+  currently degrade to `<unk>`.
 - Upstream numerical parity checks.
 - Longer-form generation validation.
 - Public semantic sampling controls.


### PR DESCRIPTION
Fixes #453.

## What changed

`IndexTTS2Tokenizer` now mirrors the upstream text front end (`indextts/utils/front.py`) ahead of the SentencePiece lattice:

- **Punctuation rewriting** — upstream's `char_rep_map` table verbatim (`。` → `.`, `，` → `,`, quotes/brackets → `'`, `:`/`;` → `,`, …) applied as a first-match-wins scan like the upstream regex, plus `$` → `.` on the Chinese path.
- **CJK pre-tokenization** — a word boundary before every CJK scalar (upstream `tokenize_by_CJK_char`, same Unicode ranges), so the lattice emits the standalone `▁` before each character that the GPT was trained on.
- **`<unk>` fallback** — one-scalar `<unk>` lattice nodes where no single-scalar piece exists (score `min − 10`, SentencePiece's `kUnkPenalty`), consecutive runs merged, with a warning logged. `unencodableText` stays in the public enum for API compatibility but is no longer thrown by the published model.
- `decode` undoes the per-character spacing; the Viterbi inner loop is bounded by the longest piece.

## Why

Verified against the published `bpe.model` (12k unigram): it has 8,467 bare single-CJK pieces, no `▁`-prefixed CJK pieces, no digit pieces, and no pieces for `。 、 " ( ) : ; … —`. Two defects followed:

1. Any of those characters threw `unencodableText` — for Mandarin (`。`) and for English (`"`, `(`, `:`).
2. Mandarin that did encode came out as `▁ 你 好 世 界` where upstream produces `▁ 你 ▁ 好 ▁ 世 ▁ 界` — a token shape the model never saw in training.

The issue's proposed fix (per-scalar CJK splitting) addresses the second; the first needed the punctuation table. Number expansion (upstream WeTextProcessing) is out of scope: digit runs become `<unk>`, and the docs say to write numbers as words.

## Tests

- Six new unit tests on a synthetic vocabulary mirroring the real layout (per-character boundaries, CJK and Latin punctuation, mixed zh/en, merged `<unk>`, digits) plus a plain-English guard. Five failed before the fix.
- `E2EIndexTTS2BundleTests/testTokenizerMatchesUpstreamTokenIDs`: eight golden id sequences from the real vocab, cross-checked against Python `sentencepiece`; runs from `INDEXTTS2_E2E_BPE_MODEL=<bpe.model>` without the full bundle.
- Differential sweep (not committed): 241 generated inputs — Mandarin, mixed, Japanese, Korean, whitespace quirks, fullwidth Latin, ligatures, ext-B and compatibility ideographs, digits — all identical to upstream `sentencepiece` output.

## Regression risk

Low and confined to the tokenizer. Plain English token ids are unchanged; English with `"`/`(`/`:` goes from crashing to working. One deliberate non-mirror: upstream skips the front end for single-character input, which yields `<unk>` for a lone `。`; this port runs the pipeline uniformly.

## Docs

`docs/models/indextts2.md` tokenizer paragraph and remaining work; `docs/inference/indextts2.md` Mandarin/numbers note and the `INDEXTTS2_E2E_BPE_MODEL` knob.
