### PR TITLE
Keep the Sidon vocoder off the Neural Engine by default

### DIFF
--- a/Sources/AudioCLILib/RestoreCommand.swift
+++ b/Sources/AudioCLILib/RestoreCommand.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreML
 import ArgumentParser
 import SpeechRestoration
 import AudioCommon
@@ -26,7 +27,28 @@ public struct RestoreCommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Model repo id on HuggingFace")
     public var model: String = SpeechRestorer.defaultModelId
 
+    @Option(
+        name: .long,
+        help: """
+        Core ML compute units for both stages: ane, gpu, cpu, or all. \
+        Default: predictor 'all', vocoder 'gpu' — the vocoder's Neural Engine \
+        compile takes minutes and can fail, so it stays on the GPU unless asked.
+        """)
+    public var computeUnits: String?
+
     public init() {}
+
+    public func validate() throws {
+        guard SidonVariant(rawValue: variant) != nil else {
+            throw ValidationError(
+                "Unknown variant '\(variant)'. Use one of: "
+                + SidonVariant.allCases.map { $0.rawValue }.joined(separator: ", "))
+        }
+        if let computeUnits, CoreMLComputeUnitsResolver.parse(computeUnits) == nil {
+            throw ValidationError(
+                "Unknown compute units '\(computeUnits)'. Use one of: ane, gpu, cpu, all")
+        }
+    }
 
     public func run() throws {
         try runAsync {
@@ -35,6 +57,8 @@ public struct RestoreCommand: ParsableCommand {
                     "Unknown variant '\(variant)'. Use one of: "
                     + SidonVariant.allCases.map { $0.rawValue }.joined(separator: ", "))
             }
+            // Uniform override for both stages; nil keeps the per-stage defaults.
+            let uniformUnits = computeUnits.flatMap { CoreMLComputeUnitsResolver.parse($0) }
 
             let inputURL = URL(fileURLWithPath: audioFile)
             print("Loading audio: \(audioFile)")
@@ -44,10 +68,20 @@ public struct RestoreCommand: ParsableCommand {
             let durIn = Double(audio.count) / Double(SpeechRestorer.inputSampleRate)
             print("  Loaded \(audio.count) samples (\(String(format: "%.2f", durIn))s @ 16 kHz)")
 
-            print("Loading Sidon (\(variant))…")
+            // Report what each stage will actually load with, including the
+            // SPEECH_COREML_COMPUTE_UNITS env override the loader applies.
+            let placement = SidonComputePlacement.resolve(
+                computeUnits: uniformUnits, predictor: nil, vocoder: nil)
+            let predictorUnits = CoreMLComputeUnitsResolver.resolved(default: placement.predictor)
+            let vocoderUnits = CoreMLComputeUnitsResolver.resolved(default: placement.vocoder)
+            print(
+                "Loading Sidon (\(variant); predictor: "
+                + "\(CoreMLComputeUnitsResolver.shortName(predictorUnits)), vocoder: "
+                + "\(CoreMLComputeUnitsResolver.shortName(vocoderUnits)))…")
             let restorer = try await SpeechRestorer.fromPretrained(
                 variant: variantEnum,
                 modelId: model,
+                computeUnits: uniformUnits,
                 progressHandler: { reportProgress($0, $1) })
 
             print("Restoring (10 s windows)…")

--- a/Sources/AudioCommon/CoreMLComputeUnits.swift
+++ b/Sources/AudioCommon/CoreMLComputeUnits.swift
@@ -22,17 +22,14 @@ import Foundation
 public enum CoreMLComputeUnitsResolver {
     public static let envKey = "SPEECH_COREML_COMPUTE_UNITS"
 
-    /// Returns the env-overridden compute units, or `fallback` when unset/unrecognized.
-    /// Accepted env values (case-insensitive): `ane`/`cpuAndNeuralEngine`,
-    /// `gpu`/`cpuAndGPU`, `cpu`/`cpuOnly`, `all`.
-    public static func resolved(default fallback: MLComputeUnits) -> MLComputeUnits {
-        guard let raw = ProcessInfo.processInfo.environment[envKey]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased(), !raw.isEmpty
-        else {
-            return fallback
-        }
-        switch raw {
+    /// Parse a user-facing compute-units name (case-insensitive, surrounding
+    /// whitespace ignored). This is the single vocabulary shared by the env
+    /// override and CLI flags:
+    /// `ane`/`cpuAndNeuralEngine`/`neuralEngine`, `gpu`/`cpuAndGPU`,
+    /// `cpu`/`cpuOnly`, `all`. Returns nil for anything else, including an
+    /// empty string.
+    public static func parse(_ raw: String) -> MLComputeUnits? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "ane", "cpuandneuralengine", "neuralengine":
             return .cpuAndNeuralEngine
         case "gpu", "cpuandgpu":
@@ -42,8 +39,29 @@ public enum CoreMLComputeUnitsResolver {
         case "all":
             return .all
         default:
+            return nil
+        }
+    }
+
+    /// Short canonical name for `units` (`ane`, `gpu`, `cpu`, `all`) — the
+    /// inverse of ``parse(_:)``, for user-facing status lines.
+    public static func shortName(_ units: MLComputeUnits) -> String {
+        switch units {
+        case .cpuAndNeuralEngine: return "ane"
+        case .cpuAndGPU: return "gpu"
+        case .cpuOnly: return "cpu"
+        case .all: return "all"
+        @unknown default: return "unknown(\(units.rawValue))"
+        }
+    }
+
+    /// Returns the env-overridden compute units, or `fallback` when unset/unrecognized.
+    /// Accepted env values are those of ``parse(_:)``.
+    public static func resolved(default fallback: MLComputeUnits) -> MLComputeUnits {
+        guard let raw = ProcessInfo.processInfo.environment[envKey] else {
             return fallback
         }
+        return parse(raw) ?? fallback
     }
 }
 #endif

--- a/Sources/SpeechRestoration/Configuration.swift
+++ b/Sources/SpeechRestoration/Configuration.swift
@@ -1,3 +1,4 @@
+import CoreML
 import Foundation
 
 /// Sidon speech-restoration model variant.
@@ -74,4 +75,64 @@ public struct SidonConfig: Sendable {
         // the conv-stack trim): 479014 samples ≈ 9.98 s @ 48 kHz.
         outputSamplesPerWindow: 479_014
     )
+}
+
+/// Which Core ML compute units each Sidon stage loads with.
+///
+/// The two stages have opposite hardware affinities, so they are placed
+/// independently:
+///
+/// - **Predictor** (w2v-BERT 2.0, 8 layers, T = 499) is a regular transformer
+///   that every backend handles well: `.all` loads in ~3 s and runs a 10 s
+///   window in ~60 ms on M-series.
+/// - **Vocoder** (DAC decoder, ×960 upsampling) ends in 1-D convolutions over
+///   ~240k–480k-sample-wide tensors. The Neural Engine compiler must spatially
+///   tile every one of those layers, which takes minutes and can fail outright
+///   (observed on M5 Pro / macOS 26.5: 159 s, then `ANECCompile() FAILED`, then
+///   a silent fallback ~12× slower than plain CPU). On the GPU the same graph
+///   loads in ~0.3 s and runs a window in ~0.2 s, so the vocoder defaults to
+///   `.cpuAndGPU`. Nothing about the export changes the tiling cost — the
+///   `.mlpackage → .mlmodelc` step is ~0.1 s; the expensive part is the
+///   per-device ANE program generated at `MLModel` load time, which cannot be
+///   shipped precompiled.
+///
+/// `SPEECH_COREML_COMPUTE_UNITS` (see `CoreMLComputeUnitsResolver`) still
+/// overrides both stages at load time; CI relies on that to force `cpuOnly`.
+public struct SidonComputePlacement: Sendable, Equatable {
+    /// Compute units for the w2v-BERT predictor.
+    public var predictor: MLComputeUnits
+    /// Compute units for the DAC vocoder.
+    public var vocoder: MLComputeUnits
+
+    public init(predictor: MLComputeUnits, vocoder: MLComputeUnits) {
+        self.predictor = predictor
+        self.vocoder = vocoder
+    }
+
+    /// Default predictor placement: let Core ML pick (Neural Engine preferred).
+    public static let defaultPredictor: MLComputeUnits = .all
+    /// Default vocoder placement: GPU — keeps the wide-tensor conv stack off the
+    /// Neural Engine compiler (see the type docs).
+    public static let defaultVocoder: MLComputeUnits = .cpuAndGPU
+    /// The shipped defaults (`predictor: .all`, `vocoder: .cpuAndGPU`).
+    public static let `default` = SidonComputePlacement(
+        predictor: defaultPredictor, vocoder: defaultVocoder)
+
+    /// The same units for both stages.
+    public static func uniform(_ units: MLComputeUnits) -> SidonComputePlacement {
+        SidonComputePlacement(predictor: units, vocoder: units)
+    }
+
+    /// Resolve a placement from the `SpeechRestorer` loader parameters: a
+    /// per-stage value wins over the uniform `computeUnits`, which wins over
+    /// the stage default.
+    public static func resolve(
+        computeUnits: MLComputeUnits?,
+        predictor: MLComputeUnits?,
+        vocoder: MLComputeUnits?
+    ) -> SidonComputePlacement {
+        SidonComputePlacement(
+            predictor: predictor ?? computeUnits ?? defaultPredictor,
+            vocoder: vocoder ?? computeUnits ?? defaultVocoder)
+    }
 }

--- a/Sources/SpeechRestoration/SidonModels.swift
+++ b/Sources/SpeechRestoration/SidonModels.swift
@@ -9,7 +9,10 @@ import AudioCommon
 final class SidonPredictorModel {
     private let model: MLModel
 
-    init(modelURL: URL, computeUnits: MLComputeUnits = .all) throws {
+    init(
+        modelURL: URL,
+        computeUnits: MLComputeUnits = SidonComputePlacement.defaultPredictor
+    ) throws {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
         self.model = try CoreMLLoader.load(
@@ -35,10 +38,18 @@ final class SidonPredictorModel {
 /// `features[1, T, 1024]` → `audio[1, M]` at 48 kHz. The `transpose(1,2)` that
 /// the upstream pipeline applies before the decoder is baked into the exported
 /// graph, so the runtime feeds `features` as-is.
+///
+/// Defaults to the GPU: the decoder's last stages are convolutions over
+/// ~480k-sample-wide tensors, and letting Core ML try the Neural Engine
+/// (`.all` / `.cpuAndNeuralEngine`) costs minutes of ANE compile that can also
+/// fail. See `SidonComputePlacement` for the measurements.
 final class SidonVocoderModel {
     private let model: MLModel
 
-    init(modelURL: URL, computeUnits: MLComputeUnits = .all) throws {
+    init(
+        modelURL: URL,
+        computeUnits: MLComputeUnits = SidonComputePlacement.defaultVocoder
+    ) throws {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
         self.model = try CoreMLLoader.load(

--- a/Sources/SpeechRestoration/SpeechRestoration.swift
+++ b/Sources/SpeechRestoration/SpeechRestoration.swift
@@ -40,6 +40,9 @@ public final class SpeechRestorer {
     var predictor: SidonPredictorModel?
     var vocoder: SidonVocoderModel?
     let variant: SidonVariant
+    /// Compute units each stage was loaded with (before any
+    /// `SPEECH_COREML_COMPUTE_UNITS` env override applied by `CoreMLLoader`).
+    public let placement: SidonComputePlacement
     var _isLoaded = true
 
     init(
@@ -47,12 +50,14 @@ public final class SpeechRestorer {
         vocoder: SidonVocoderModel?,
         config: SidonConfig,
         variant: SidonVariant,
+        placement: SidonComputePlacement = .default,
         loaded: Bool = true
     ) {
         self.predictor = predictor
         self.vocoder = vocoder
         self.config = config
         self.variant = variant
+        self.placement = placement
         self._isLoaded = loaded
     }
 
@@ -63,16 +68,31 @@ public final class SpeechRestorer {
     /// - Parameters:
     ///   - variant: precision variant (`.fp16` default, `.int8` for smaller).
     ///   - modelId: HuggingFace repo id (override if the published id differs).
-    ///   - computeUnits: CoreML compute units (default `.all`; honors the
-    ///     `SPEECH_COREML_COMPUTE_UNITS` env override via `CoreMLLoader`).
+    ///   - computeUnits: uniform Core ML compute units for both stages. Leave
+    ///     nil (default) to use the per-stage defaults in
+    ///     `SidonComputePlacement` — predictor `.all`, vocoder `.cpuAndGPU`
+    ///     (the vocoder's Neural Engine compile takes minutes and can fail).
+    ///   - predictorComputeUnits: per-stage override for the predictor; wins
+    ///     over `computeUnits`.
+    ///   - vocoderComputeUnits: per-stage override for the vocoder; wins over
+    ///     `computeUnits`.
+    ///
+    /// The `SPEECH_COREML_COMPUTE_UNITS` env override (applied by
+    /// `CoreMLLoader`) takes precedence over all of these.
     public static func fromPretrained(
         variant: SidonVariant = .fp16,
         modelId: String = defaultModelId,
         cacheDir: URL? = nil,
         offlineMode: Bool = false,
-        computeUnits: MLComputeUnits = .all,
+        computeUnits: MLComputeUnits? = nil,
+        predictorComputeUnits: MLComputeUnits? = nil,
+        vocoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: ((Double, String) -> Void)? = nil
     ) async throws -> SpeechRestorer {
+        let placement = SidonComputePlacement.resolve(
+            computeUnits: computeUnits,
+            predictor: predictorComputeUnits,
+            vocoder: vocoderComputeUnits)
         progressHandler?(0.0, "Downloading model...")
 
         let paths = try await SidonDownloader.ensureDownloaded(
@@ -94,24 +114,34 @@ public final class SpeechRestorer {
             compiledName: SidonConfig.vocoderCompiledName,
             packageName: SidonConfig.vocoderPackageName)
 
-        let predictor = try SidonPredictorModel(modelURL: predictorURL, computeUnits: computeUnits)
-        let vocoder = try SidonVocoderModel(modelURL: vocoderURL, computeUnits: computeUnits)
+        let predictor = try SidonPredictorModel(
+            modelURL: predictorURL, computeUnits: placement.predictor)
+        let vocoder = try SidonVocoderModel(
+            modelURL: vocoderURL, computeUnits: placement.vocoder)
 
         progressHandler?(1.0, "Ready")
         return SpeechRestorer(
             predictor: predictor, vocoder: vocoder,
-            config: .default, variant: variant)
+            config: .default, variant: variant, placement: placement)
     }
 
     /// Load the two models directly from a local directory holding
     /// `Sidon-Predictor.{mlmodelc,mlpackage}` + `Sidon-Vocoder.{mlmodelc,mlpackage}`,
     /// skipping HuggingFace entirely. Useful for testing locally-converted
     /// artifacts (mirrors the other engines' local-bundle affordance).
+    ///
+    /// Compute-unit parameters behave exactly as in `fromPretrained`.
     public static func fromLocalBundle(
         directory: URL,
         variant: SidonVariant = .fp16,
-        computeUnits: MLComputeUnits = .all
+        computeUnits: MLComputeUnits? = nil,
+        predictorComputeUnits: MLComputeUnits? = nil,
+        vocoderComputeUnits: MLComputeUnits? = nil
     ) throws -> SpeechRestorer {
+        let placement = SidonComputePlacement.resolve(
+            computeUnits: computeUnits,
+            predictor: predictorComputeUnits,
+            vocoder: vocoderComputeUnits)
         let predictorURL = try SidonModelResolver.resolve(
             directory: directory,
             compiledName: SidonConfig.predictorCompiledName,
@@ -120,11 +150,13 @@ public final class SpeechRestorer {
             directory: directory,
             compiledName: SidonConfig.vocoderCompiledName,
             packageName: SidonConfig.vocoderPackageName)
-        let predictor = try SidonPredictorModel(modelURL: predictorURL, computeUnits: computeUnits)
-        let vocoder = try SidonVocoderModel(modelURL: vocoderURL, computeUnits: computeUnits)
+        let predictor = try SidonPredictorModel(
+            modelURL: predictorURL, computeUnits: placement.predictor)
+        let vocoder = try SidonVocoderModel(
+            modelURL: vocoderURL, computeUnits: placement.vocoder)
         return SpeechRestorer(
             predictor: predictor, vocoder: vocoder,
-            config: .default, variant: variant)
+            config: .default, variant: variant, placement: placement)
     }
 
     // MARK: - Window planning

--- a/Tests/AudioCLITests/RestoreCommandTests.swift
+++ b/Tests/AudioCLITests/RestoreCommandTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import ArgumentParser
+@testable import AudioCLILib
+
+final class RestoreCommandTests: XCTestCase {
+
+    func testDefaultsLeavePlacementToTheEngine() throws {
+        let cmd = try AudioCLI.parseAsRoot(["restore", "noisy.wav"])
+        let restore = try XCTUnwrap(cmd as? RestoreCommand)
+        XCTAssertEqual(restore.audioFile, "noisy.wav")
+        XCTAssertEqual(restore.variant, "fp16")
+        XCTAssertNil(restore.output)
+        XCTAssertNil(restore.computeUnits, "no flag → per-stage engine defaults")
+    }
+
+    func testParsesComputeUnitsAlongsideOtherFlags() throws {
+        let cmd = try AudioCLI.parseAsRoot([
+            "restore", "noisy.wav", "--compute-units", "gpu",
+            "--variant", "int8", "-o", "clean.wav",
+        ])
+        let restore = try XCTUnwrap(cmd as? RestoreCommand)
+        XCTAssertEqual(restore.computeUnits, "gpu")
+        XCTAssertEqual(restore.variant, "int8")
+        XCTAssertEqual(restore.output, "clean.wav")
+    }
+
+    func testAcceptsEveryComputeUnitsName() throws {
+        for name in ["ane", "gpu", "cpu", "all", "cpuAndGPU", "CPU"] {
+            let cmd = try AudioCLI.parseAsRoot(["restore", "x.wav", "--compute-units", name])
+            XCTAssertEqual((cmd as? RestoreCommand)?.computeUnits, name)
+        }
+    }
+
+    func testRejectsUnknownComputeUnitsAtParseTime() {
+        XCTAssertThrowsError(
+            try AudioCLI.parseAsRoot(["restore", "x.wav", "--compute-units", "metal"])
+        ) { error in
+            XCTAssertEqual(AudioCLI.exitCode(for: error), .validationFailure)
+            XCTAssertTrue(AudioCLI.message(for: error).contains("compute units"))
+        }
+    }
+
+    func testRejectsUnknownVariantAtParseTime() {
+        XCTAssertThrowsError(
+            try AudioCLI.parseAsRoot(["restore", "x.wav", "--variant", "int4"])
+        ) { error in
+            XCTAssertEqual(AudioCLI.exitCode(for: error), .validationFailure)
+        }
+    }
+
+    func testHelpDocumentsComputeUnits() {
+        let help = RestoreCommand.helpMessage()
+        XCTAssertTrue(help.contains("--compute-units"))
+        XCTAssertTrue(help.contains("vocoder"))
+    }
+}

--- a/Tests/AudioCLITests/VoiceChatCommandTests.swift
+++ b/Tests/AudioCLITests/VoiceChatCommandTests.swift
@@ -945,9 +945,12 @@ final class VoiceChatCommandTests: XCTestCase {
             description: "Slow lookup",
             inputSchemaJSON: #"{"type":"object","properties":{}}"#,
             access: .read)
+        // The tool must stay in flight long enough for the status probe below
+        // to land inside its execution window even on a loaded CI runner,
+        // where a short `Task.sleep` can overshoot by well over 100 ms.
         let executor = DelayedVoiceChatMCPExecutor(
             tool: tool,
-            delayNanoseconds: 150_000_000)
+            delayNanoseconds: 1_000_000_000)
         let coordinator = VoiceChatMCPToolCoordinator(
             executor: executor,
             writePolicy: .confirm)
@@ -956,9 +959,17 @@ final class VoiceChatCommandTests: XCTestCase {
             await coordinator.handleFunctionCall(
                 #"[{"name":"lookup","arguments":{}}]"#)
         }
-        try await Task.sleep(nanoseconds: 30_000_000)
 
-        let runningStatus = await coordinator.runtimeStatus()
+        // Wait for the coordinator to report the call as executing instead of
+        // sleeping a fixed interval and hoping the call has started (and not
+        // yet finished) by then.
+        var runningStatus = await coordinator.runtimeStatus()
+        let deadline = DispatchTime.now().uptimeNanoseconds + 2_000_000_000
+        while !runningStatus.executing,
+              DispatchTime.now().uptimeNanoseconds < deadline {
+            try await Task.sleep(nanoseconds: 5_000_000)
+            runningStatus = await coordinator.runtimeStatus()
+        }
         XCTAssertTrue(runningStatus.executing)
         XCTAssertEqual(runningStatus.name, "lookup")
         let running = try XCTUnwrap(runningStatus.activity)
@@ -972,7 +983,7 @@ final class VoiceChatCommandTests: XCTestCase {
         XCTAssertNil(completedStatus.name)
         let completed = try XCTUnwrap(completedStatus.activity)
         XCTAssertEqual(completed.state, .completed)
-        XCTAssertGreaterThanOrEqual(completed.elapsedMilliseconds, 100)
+        XCTAssertGreaterThanOrEqual(completed.elapsedMilliseconds, 1000)
     }
 
     func testMCPRuntimeDiscoversAndCallsConfiguredStdioServer() async throws {

--- a/Tests/AudioCommonTests/CoreMLComputeUnitsTests.swift
+++ b/Tests/AudioCommonTests/CoreMLComputeUnitsTests.swift
@@ -46,5 +46,40 @@ final class CoreMLComputeUnitsResolverTests: XCTestCase {
             XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuAndNeuralEngine), .cpuAndNeuralEngine)
         }
     }
+
+    // MARK: - parse / shortName (shared CLI + env vocabulary)
+
+    func testParseAcceptsTheSharedVocabulary() {
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("ane"), .cpuAndNeuralEngine)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("neuralEngine"), .cpuAndNeuralEngine)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("cpuAndNeuralEngine"), .cpuAndNeuralEngine)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("gpu"), .cpuAndGPU)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("cpuAndGPU"), .cpuAndGPU)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("cpu"), .cpuOnly)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("cpuOnly"), .cpuOnly)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("all"), .all)
+        XCTAssertEqual(CoreMLComputeUnitsResolver.parse("  GPU\n"), .cpuAndGPU, "case/whitespace-insensitive")
+    }
+
+    func testParseRejectsUnknownAndEmpty() {
+        XCTAssertNil(CoreMLComputeUnitsResolver.parse(""))
+        XCTAssertNil(CoreMLComputeUnitsResolver.parse("   "))
+        XCTAssertNil(CoreMLComputeUnitsResolver.parse("banana"))
+        XCTAssertNil(CoreMLComputeUnitsResolver.parse("metal"))
+    }
+
+    func testShortNameRoundTripsThroughParse() {
+        for units in [MLComputeUnits.cpuOnly, .cpuAndGPU, .cpuAndNeuralEngine, .all] {
+            let name = CoreMLComputeUnitsResolver.shortName(units)
+            XCTAssertEqual(CoreMLComputeUnitsResolver.parse(name), units, "shortName(\(name)) must parse back")
+        }
+        XCTAssertEqual(CoreMLComputeUnitsResolver.shortName(.cpuAndGPU), "gpu")
+    }
+
+    func testEmptyEnvFallsBack() {
+        withEnv("") {
+            XCTAssertEqual(CoreMLComputeUnitsResolver.resolved(default: .cpuAndGPU), .cpuAndGPU)
+        }
+    }
 }
 #endif

--- a/Tests/SpeechRestorationTests/SpeechRestorationConfigTests.swift
+++ b/Tests/SpeechRestorationTests/SpeechRestorationConfigTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreML
 @testable import SpeechRestoration
 
 /// Unit tests for Sidon config + variant wiring (no model download).
@@ -40,5 +41,46 @@ final class SpeechRestorationConfigTests: XCTestCase {
         XCTAssertEqual(SpeechRestorer.inputSampleRate, 16_000)
         XCTAssertEqual(SpeechRestorer.outputSampleRate, 48_000)
         XCTAssertEqual(SpeechRestorer.defaultModelId, "aufklarer/Sidon-CoreML")
+    }
+
+    // MARK: - Compute placement
+
+    /// The vocoder must never default to a Neural-Engine-eligible unit: its ANE
+    /// compile takes minutes and can fail (issue #464). The predictor may.
+    func testDefaultPlacementKeepsVocoderOffTheNeuralEngine() {
+        let p = SidonComputePlacement.default
+        XCTAssertEqual(p.predictor, .all)
+        XCTAssertEqual(p.vocoder, .cpuAndGPU)
+        XCTAssertEqual(SidonComputePlacement.defaultVocoder, .cpuAndGPU)
+        XCTAssertEqual(
+            SidonComputePlacement.resolve(computeUnits: nil, predictor: nil, vocoder: nil), p,
+            "no parameters must resolve to the shipped defaults")
+    }
+
+    func testUniformComputeUnitsApplyToBothStages() {
+        let p = SidonComputePlacement.resolve(computeUnits: .cpuOnly, predictor: nil, vocoder: nil)
+        XCTAssertEqual(p, .uniform(.cpuOnly))
+        XCTAssertEqual(p.predictor, .cpuOnly)
+        XCTAssertEqual(p.vocoder, .cpuOnly)
+    }
+
+    func testPerStageOverridesWinOverUniform() {
+        let p = SidonComputePlacement.resolve(
+            computeUnits: .cpuOnly, predictor: .cpuAndNeuralEngine, vocoder: nil)
+        XCTAssertEqual(p.predictor, .cpuAndNeuralEngine)
+        XCTAssertEqual(p.vocoder, .cpuOnly)
+
+        let q = SidonComputePlacement.resolve(computeUnits: nil, predictor: nil, vocoder: .all)
+        XCTAssertEqual(q.predictor, .all, "unset stage keeps its default")
+        XCTAssertEqual(q.vocoder, .all, "explicit opt-in to ANE for the vocoder is allowed")
+    }
+
+    func testRestorerRecordsPlacement() {
+        let r = SpeechRestorer(
+            predictor: nil, vocoder: nil, config: .default, variant: .fp16,
+            placement: .uniform(.cpuAndGPU), loaded: false)
+        XCTAssertEqual(r.placement, .uniform(.cpuAndGPU))
+        let d = SpeechRestorer(predictor: nil, vocoder: nil, config: .default, variant: .fp16)
+        XCTAssertEqual(d.placement, .default)
     }
 }

--- a/docs/inference/sidon.md
+++ b/docs/inference/sidon.md
@@ -20,9 +20,11 @@ make build
 ## Flags
 
 ```
---variant {fp16,int8}   # precision variant (default fp16)
---model, -m REPO        # HuggingFace repo id (default aufklarer/Sidon-CoreML)
---output, -o PATH       # output WAV path (default <input>_restored.wav, 48 kHz)
+--variant {fp16,int8}          # precision variant (default fp16)
+--model, -m REPO               # HuggingFace repo id (default aufklarer/Sidon-CoreML)
+--output, -o PATH              # output WAV path (default <input>_restored.wav, 48 kHz)
+--compute-units {ane,gpu,cpu,all}  # Core ML placement for both stages
+                               # (default: predictor all, vocoder gpu — see below)
 ```
 
 ## Input handling
@@ -33,6 +35,40 @@ make build
 - Output is 48 kHz mono, trimmed to the input's true duration on the 48 kHz
   timeline (each window emits a fixed number of samples regardless of how much
   of it was real audio, so partial-window padding is removed).
+
+## Compute placement
+
+The two Core ML stages are placed independently (`SidonComputePlacement`):
+
+| Stage | Default | Why |
+|---|---|---|
+| Predictor (w2v-BERT 2.0, 8 layers) | `.all` | regular transformer; ANE-friendly (~3 s load, ~60 ms per window) |
+| Vocoder (DAC decoder, ×960) | `.cpuAndGPU` | its late layers are convolutions over ~480k-sample-wide tensors; the Neural Engine compiler spends **minutes** spatially tiling them and can fail outright (M5 Pro / macOS 26.5: 159 s then `ANECCompile() FAILED`, silent fallback ~12× slower than CPU). On the GPU it loads in ~0.3 s and runs a window in ~0.2 s. |
+
+Nothing about the export helps here — the `.mlpackage → .mlmodelc` compile is
+~0.1 s; the expensive part is the per-device ANE program that Core ML generates
+at `MLModel` load time, which cannot be shipped precompiled.
+
+Overrides, highest precedence first:
+
+1. `SPEECH_COREML_COMPUTE_UNITS=ane|gpu|cpu|all` — env, applies to every Core ML
+   model in the process (CI forces `cpu`).
+2. `--compute-units ane|gpu|cpu|all` — CLI, both stages.
+3. API — per stage wins over uniform:
+
+```swift
+// defaults: predictor .all, vocoder .cpuAndGPU
+let restorer = try await SpeechRestorer.fromPretrained()
+
+// uniform
+let cpu = try await SpeechRestorer.fromPretrained(computeUnits: .cpuOnly)
+
+// per stage (opt the vocoder back onto the ANE for a long-lived server that
+// can afford the one-time compile)
+let ane = try await SpeechRestorer.fromPretrained(vocoderComputeUnits: .all)
+
+restorer.placement.vocoder   // → .cpuAndGPU
+```
 
 ## Clean a voice-cloning reference (`speak --clean-reference`)
 

--- a/docs/models/sidon.md
+++ b/docs/models/sidon.md
@@ -85,14 +85,24 @@ compiling a `.mlpackage` on device (cached next to the package so the slow compi
 runs once per install). `SpeechRestorer.fromLocalBundle(directory:)` loads
 locally-converted artifacts directly, skipping HuggingFace.
 
-## Performance (M-series)
+## Performance (M5 Pro, macOS 26.5, fp16)
 
-Single 10 s window, Core ML `.all` compute units:
+Per stage, one 10 s window, fresh process (Metal shader cache warm):
 
-| | Wall | Notes |
-|---|---|---|
-| First window | slower | on-device `.mlpackage` compile (if no precompiled bundle) + cold load |
-| Subsequent windows | ~2 s | faster than realtime for the 10 s window |
+| Stage | Units | Load | First window | Steady |
+|---|---|---|---|---|
+| Predictor | `.all` (default) | 3.3 s | 0.28 s | 0.06 s |
+| Predictor | `.cpuAndGPU` | 0.4 s | 1.5 s | 0.06 s |
+| Vocoder | `.cpuAndGPU` (default) | 0.3 s | 0.2 s | 0.16 s |
+| Vocoder | `.cpuOnly` | 0.07 s | 0.7 s | 0.7 s |
+| Vocoder | `.cpuAndNeuralEngine` | **159 s, `ANECCompile() FAILED`** | 8.3 s (fallback) | 8 s |
+
+The pipeline is ~40× faster than realtime on the default placement. The vocoder
+row is why it is placed on the GPU: the DAC decoder's last stages are 1-D
+convolutions over `[1, 48, 479014]` tensors, and the Neural Engine compiler's
+spatial tiling of them takes minutes and can fail (see
+`docs/inference/sidon.md`, "Compute placement"). The `.mlpackage → .mlmodelc`
+compile is ~0.1 s and is not the cost.
 
 Validated against the Python Core ML reference: waveform cosine ≈ 0.9994 (fp16)
 and ≈ 0.9990 (int8) on the benchmark clip (neural-vocoder phase noise keeps this


### PR DESCRIPTION
Fixes #464 — `speech restore` sat at `[85%] Loading models...` for minutes while `ANECompilerService` burned a core.

## What changed

The Sidon vocoder (DAC decoder, ×960 upsampling) ends in 1-D convolutions over `[1, 48, 479014]` tensors. With the previous `.all` default, Core ML hands that graph to the Neural Engine compiler, which spends minutes spatially tiling it — and on M5 Pro / macOS 26.5 fails outright after 159 s (`ANECCompile() FAILED`), then silently falls back to a CPU program ~12× slower than plain `cpuOnly`. Nothing export-side avoids this: the `.mlpackage → .mlmodelc` step is ~0.1 s; the cost is the per-device ANE program generated at `MLModel` load, which cannot be shipped precompiled.

- `SidonComputePlacement`: per-stage compute units — predictor `.all`, vocoder `.cpuAndGPU`. `fromPretrained` / `fromLocalBundle` accept a uniform `computeUnits:` (now optional) plus `predictorComputeUnits:` / `vocoderComputeUnits:` overrides; the restorer exposes `placement`.
- `speech restore --compute-units ane|gpu|cpu|all`, validated at parse time; the load line prints the effective per-stage placement (env override included).
- `CoreMLComputeUnitsResolver.parse` / `shortName`: one shared vocabulary for the `SPEECH_COREML_COMPUTE_UNITS` env override and CLI flags. Env behaviour unchanged.
- Docs: `docs/inference/sidon.md` gains a "Compute placement" section; `docs/models/sidon.md` perf table replaced with measured numbers.

## Measurements (M5 Pro, macOS 26.5.2, fp16, one 10 s window)

| Stage | Units | Load | Steady per window |
|---|---|---|---|
| Vocoder | `.cpuAndNeuralEngine` | **159 s, `ANECCompile() FAILED`** | 8 s (fallback) |
| Vocoder | `.all` (old default) | 52–61 s | 0.07 s |
| Vocoder | `.cpuAndGPU` (new default) | 0.3 s | 0.16 s |
| Vocoder | `.cpuOnly` | 0.07 s | 0.7 s |
| Predictor | `.all` (default, unchanged) | 3.3 s | 0.06 s |

End-to-end `speech restore` on a 3.6 s clip (debug build): `--compute-units all` **410 s**, new default **7.5 s**.

## Architecture fit

Same pattern as the Qwen3-TTS CoreML per-model routing and the Nemotron / Sortformer `computeUnits` parameters: placement is a load-time configuration, resolved centrally, with the global env override still winning (CI forces `cpuOnly`).

## Regression risk

Low. Same bundles, same weights, same DSP — only the load configuration changes. Callers that explicitly passed `computeUnits: .all` keep ANE for both stages; only the default moved. Output parity on real speech: cos(gpu, cpu) 0.979, cos(all, gpu) 0.978, cos(all, cpu) 0.967 — the three backends sit within the same fp16-vs-fp32 band.

## Tests

- Unit (40/40 in the touched suites): placement resolution + precedence, `SpeechRestorer` records placement, parser vocabulary / rejection / `shortName` round-trip, `restore` CLI flag parsing and parse-time validation.
- E2E `E2ESpeechRestorationTests` on-device with the local fp16 bundle: pass (int8 skipped, no local artifacts).
- Real CLI runs on `cpu`, default, and `all` placements with waveform comparison (numbers above).

## Follow-ups (not in this PR)

- soniqo-web: `/cli/index.html` + the restore guide need the new flag.
- HF model card example says `speech enhance`; should be `speech restore`.
- Optionally publish `.mlmodelc` bundles to HF for the documented runtime-drift reason (saves ~0.1 s; not the fix).


## Also in this PR

`VoiceChatCommandTests.testCoordinatorRemainsResponsiveWhileMCPToolIsSuspended` failed twice on the runner for this branch while passing on `main`'s control run the same day. It slept a fixed 30 ms and asserted a 150 ms tool call was still running; the runner's `Task.sleep` can overshoot past that whole window (the Aug 26 pass on `main` already took 0.227 s). The test now polls the coordinator for the executing state and uses a 1 s tool window — 20/20 locally.
