### PR TITLE
Read numbers out before IndexTTS2 tokenization

### DIFF
--- a/Sources/IndexTTS2TTS/IndexTTS2TextNormalizer.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2TextNormalizer.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+/// Compact number normalizer standing in for the WeTextProcessing pass
+/// (`tn.chinese` / `tn.english`) that upstream IndexTTS2 runs before
+/// `char_rep_map` and CJK pre-tokenization. The vocabulary has no digit
+/// pieces, so anything left as digits tokenizes to `<unk>`.
+///
+/// Covers the readings that show up in ordinary prose — cardinals, years,
+/// dates, times, decimals, percentages, fractions, money, ordinals,
+/// negatives, thousands separators, mobile numbers — and leaves everything
+/// else untouched. It is not a port of the upstream FST grammars.
+struct IndexTTS2TextNormalizer {
+    static func normalize(_ text: String) -> String {
+        guard text.unicodeScalars.contains(where: Self.isDigit) else { return text }
+        let folded = foldFullwidthDigits(text)
+        return usesChineseFrontEnd(folded) ? normalizeChinese(folded) : normalizeEnglish(folded)
+    }
+
+    /// Upstream `use_chinese`: Han text, or text with no Latin letters at all.
+    static func usesChineseFrontEnd(_ text: String) -> Bool {
+        let scalars = text.unicodeScalars
+        let hasHan = scalars.contains { (0x4E00...0x9FFF).contains($0.value) }
+        let hasLatinLetter = scalars.contains { isLatinLetter($0) }
+        return hasHan || !hasLatinLetter
+    }
+
+    // MARK: - Chinese
+
+    private static func normalizeChinese(_ text: String) -> String {
+        var s = stripThousandsSeparators(text)
+        s = Self.zhPercent.replace(in: s) { "百分之" + zhNumber($0[1]) }
+        s = Self.fraction.replace(in: s) { zhCardinal($0[2]) + "分之" + zhCardinal($0[1]) }
+        s = Self.zhDollars.replace(in: s) { zhNumber($0[1]) + "美元" }
+        s = Self.zhYuan.replace(in: s) { zhNumber($0[1]) + "元" }
+        s = Self.clockTime.replace(in: s) { groups in
+            let minute = groups[2]
+            var reading = zhCardinal(groups[1]) + "点"
+            if minute != "00" {
+                reading += (minute.hasPrefix("0") ? "零" + zhDigits(String(minute.dropFirst())) : zhCardinal(minute)) + "分"
+            }
+            return reading
+        }
+        s = Self.zhYear.replace(in: s) { zhDigits($0[1]) + "年" }
+        s = Self.zhMobileNumber.replace(in: s) { zhDigits($0[1]) }
+        s = Self.negative.replace(in: s) { "负" + zhNumber($0[1]) }
+        s = Self.decimal.replace(in: s) { zhCardinal($0[1]) + "点" + zhDigits($0[2]) }
+        s = Self.integer.replace(in: s) { zhInteger($0[0]) }
+        return s
+    }
+
+    private static let zhNumerals = ["零", "一", "二", "三", "四", "五", "六", "七", "八", "九"]
+    private static let zhUnits = ["", "十", "百", "千"]
+    private static let zhSections = ["", "万", "亿"]
+
+    private static func zhNumber(_ s: String) -> String {
+        guard let dot = s.firstIndex(of: ".") else { return zhInteger(s) }
+        return zhCardinal(String(s[..<dot])) + "点" + zhDigits(String(s[s.index(after: dot)...]))
+    }
+
+    private static func zhInteger(_ digits: String) -> String {
+        if (digits.hasPrefix("0") && digits.count > 1) || digits.count > 12 {
+            return zhDigits(digits)
+        }
+        return zhCardinal(digits)
+    }
+
+    private static func zhDigits(_ digits: String) -> String {
+        digits.compactMap { $0.wholeNumberValue.map { zhNumerals[$0] } }.joined()
+    }
+
+    /// Standard cardinal reading with 万/亿 sections and single 零 for zero gaps.
+    private static func zhCardinal(_ digitString: String) -> String {
+        let all = digitString.compactMap(\.wholeNumberValue)
+        guard let first = all.firstIndex(where: { $0 != 0 }), all.count <= 12 else {
+            return all.isEmpty ? "" : (all.allSatisfy { $0 == 0 } ? "零" : zhDigits(digitString))
+        }
+        let digits = Array(all[first...])
+        var result = ""
+        var pendingZero = false
+        var sectionHasValue = false
+        for (index, digit) in digits.enumerated() {
+            let position = digits.count - 1 - index
+            let unit = position % 4
+            let section = position / 4
+            if digit == 0 {
+                pendingZero = !result.isEmpty
+            } else {
+                if pendingZero { result += "零" }
+                pendingZero = false
+                sectionHasValue = true
+                result += zhNumerals[digit] + zhUnits[unit]
+            }
+            if unit == 0 && section > 0 {
+                if sectionHasValue {
+                    result += zhSections[section]
+                    pendingZero = false
+                }
+                sectionHasValue = false
+            }
+        }
+        if result.hasPrefix("一十") { result.removeFirst() }
+        return result
+    }
+
+    // MARK: - English
+
+    private static func normalizeEnglish(_ text: String) -> String {
+        var s = stripThousandsSeparators(text)
+        s = Self.enOrdinal.replace(in: s, padLetters: true) { enOrdinal($0[1]) }
+        s = Self.enPercent.replace(in: s, padLetters: true) { enNumber($0[1]) + " percent" }
+        s = Self.enDollars.replace(in: s, padLetters: true) { enMoney(dollars: $0[1], cents: $0[2]) }
+        s = Self.clockTime.replace(in: s, padLetters: true) { enTime(hour: $0[1], minute: $0[2]) }
+        s = Self.negative.replace(in: s, padLetters: true) { "minus " + enNumber($0[1]) }
+        s = Self.decimal.replace(in: s, padLetters: true) { enCardinal($0[1]) + " point " + enDigits($0[2]) }
+        s = Self.enYear.replace(in: s, padLetters: true) { enYear($0[1]) }
+        s = Self.integer.replace(in: s, padLetters: true) { enInteger($0[0]) }
+        return s
+    }
+
+    private static let enOnes = [
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen",
+    ]
+    private static let enTens = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"]
+    private static let enScales = ["", "thousand", "million", "billion", "trillion"]
+    private static let enIrregularOrdinals = [
+        "one": "first", "two": "second", "three": "third", "five": "fifth", "eight": "eighth",
+        "nine": "ninth", "twelve": "twelfth",
+    ]
+
+    private static func enNumber(_ s: String) -> String {
+        guard let dot = s.firstIndex(of: ".") else { return enInteger(s) }
+        return enCardinal(String(s[..<dot])) + " point " + enDigits(String(s[s.index(after: dot)...]))
+    }
+
+    private static func enInteger(_ digits: String) -> String {
+        if (digits.hasPrefix("0") && digits.count > 1) || digits.count > 15 {
+            return enDigits(digits)
+        }
+        return enCardinal(digits)
+    }
+
+    private static func enDigits(_ digits: String) -> String {
+        digits.compactMap { $0.wholeNumberValue.map { enOnes[$0] } }.joined(separator: " ")
+    }
+
+    private static func enCardinal(_ digitString: String) -> String {
+        guard let value = Int(digitString) else { return digitString }
+        return enCardinal(value)
+    }
+
+    private static func enCardinal(_ value: Int) -> String {
+        if value < 20 { return enOnes[value] }
+        if value < 100 {
+            return enTens[value / 10] + (value % 10 == 0 ? "" : " " + enOnes[value % 10])
+        }
+        if value < 1_000 {
+            return enOnes[value / 100] + " hundred" + (value % 100 == 0 ? "" : " " + enCardinal(value % 100))
+        }
+        var remainder = value
+        var scale = 0
+        var parts: [String] = []
+        while remainder > 0 && scale < enScales.count {
+            let chunk = remainder % 1_000
+            if chunk > 0 {
+                parts.insert(enCardinal(chunk) + (scale == 0 ? "" : " " + enScales[scale]), at: 0)
+            }
+            remainder /= 1_000
+            scale += 1
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private static func enOrdinal(_ digits: String) -> String {
+        var words = enCardinal(digits).split(separator: " ").map(String.init)
+        guard let last = words.popLast() else { return digits }
+        let ordinal: String
+        if let irregular = enIrregularOrdinals[last] {
+            ordinal = irregular
+        } else if last.hasSuffix("y") {
+            ordinal = String(last.dropLast()) + "ieth"
+        } else {
+            ordinal = last + "th"
+        }
+        return (words + [ordinal]).joined(separator: " ")
+    }
+
+    private static func enYear(_ digits: String) -> String {
+        guard let year = Int(digits), (1_100...2_099).contains(year) else { return enCardinal(digits) }
+        let high = year / 100
+        let low = year % 100
+        if (2_000...2_009).contains(year) {
+            return "two thousand" + (low == 0 ? "" : " " + enCardinal(low))
+        }
+        if low == 0 { return enCardinal(high) + " hundred" }
+        if low < 10 { return enCardinal(high) + " oh " + enOnes[low] }
+        return enCardinal(high) + " " + enCardinal(low)
+    }
+
+    private static func enMoney(dollars: String, cents: String) -> String {
+        let dollarValue = Int(dollars) ?? 0
+        let centValue = cents.isEmpty ? 0 : Int(cents.count == 1 ? cents + "0" : cents) ?? 0
+        var parts: [String] = []
+        if dollarValue > 0 || centValue == 0 {
+            parts.append(enCardinal(dollarValue) + (dollarValue == 1 ? " dollar" : " dollars"))
+        }
+        if centValue > 0 {
+            parts.append(enCardinal(centValue) + (centValue == 1 ? " cent" : " cents"))
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private static func enTime(hour: String, minute: String) -> String {
+        let hourWords = enCardinal(hour)
+        guard let minuteValue = Int(minute) else { return hourWords }
+        if minuteValue == 0 { return hourWords + " o'clock" }
+        if minuteValue < 10 { return hourWords + " oh " + enOnes[minuteValue] }
+        return hourWords + " " + enCardinal(minuteValue)
+    }
+
+    // MARK: - Shared patterns
+
+    private static let thousandsSeparator = Pattern("(?<=[0-9])[,，](?=[0-9]{3}(?![0-9]))")
+    private static let fraction = Pattern("(?<![0-9])([0-9]+)/([0-9]+)(?![0-9])")
+    private static let clockTime = Pattern("(?<![0-9])([0-9]{1,2}):([0-9]{2})(?![0-9:])")
+    private static let negative = Pattern("(?<![0-9A-Za-z])-([0-9]+(?:\\.[0-9]+)?)")
+    private static let decimal = Pattern("([0-9]+)\\.([0-9]+)")
+    private static let integer = Pattern("[0-9]+")
+    private static let zhPercent = Pattern("([0-9]+(?:\\.[0-9]+)?)\\s*[%％]")
+    private static let zhDollars = Pattern("[$＄]([0-9]+(?:\\.[0-9]+)?)")
+    private static let zhYuan = Pattern("[¥￥]([0-9]+(?:\\.[0-9]+)?)")
+    private static let zhYear = Pattern("(?<![0-9])([0-9]{2,4})年")
+    private static let zhMobileNumber = Pattern("(?<![0-9])(1[3-9][0-9]{9})(?![0-9])")
+    private static let enOrdinal = Pattern("(?<![0-9])([0-9]+)(?:st|nd|rd|th)\\b", options: [.caseInsensitive])
+    private static let enPercent = Pattern("([0-9]+(?:\\.[0-9]+)?)\\s*%")
+    private static let enDollars = Pattern("\\$([0-9]+)(?:\\.([0-9]{1,2}))?(?![0-9])")
+    private static let enYear = Pattern("(?<![0-9A-Za-z])([1-9][0-9]{3})(?![0-9A-Za-z])")
+
+    private static func stripThousandsSeparators(_ text: String) -> String {
+        thousandsSeparator.replace(in: text) { _ in "" }
+    }
+
+    private static func foldFullwidthDigits(_ text: String) -> String {
+        String(String.UnicodeScalarView(text.unicodeScalars.map { scalar in
+            (0xFF10...0xFF19).contains(scalar.value) ? Unicode.Scalar(scalar.value - 0xFF10 + 0x30)! : scalar
+        }))
+    }
+
+    private static func isDigit(_ scalar: Unicode.Scalar) -> Bool {
+        (0x30...0x39).contains(scalar.value) || (0xFF10...0xFF19).contains(scalar.value)
+    }
+
+    private static func isLatinLetter(_ scalar: Unicode.Scalar) -> Bool {
+        (0x41...0x5A).contains(scalar.value) || (0x61...0x7A).contains(scalar.value)
+    }
+
+    private struct Pattern: @unchecked Sendable {
+        let regex: NSRegularExpression
+
+        init(_ pattern: String, options: NSRegularExpression.Options = []) {
+            // Patterns are static literals; a malformed one is a programming error.
+            regex = try! NSRegularExpression(pattern: pattern, options: options)
+        }
+
+        /// Replaces every match with `transform(groups)`, where `groups[0]` is
+        /// the whole match. With `padLetters`, a replacement that touches a
+        /// Latin letter gets a space on that side so number words stay separate.
+        func replace(in text: String, padLetters: Bool = false, _ transform: ([String]) -> String) -> String {
+            let source = text as NSString
+            let matches = regex.matches(in: text, range: NSRange(location: 0, length: source.length))
+            guard !matches.isEmpty else { return text }
+            var result = source
+            for match in matches.reversed() {
+                let groups = (0..<match.numberOfRanges).map { index -> String in
+                    let range = match.range(at: index)
+                    return range.location == NSNotFound ? "" : source.substring(with: range)
+                }
+                var replacement = transform(groups)
+                if padLetters {
+                    if match.range.location > 0,
+                       Self.isLetter(source.character(at: match.range.location - 1)) {
+                        replacement = " " + replacement
+                    }
+                    let end = match.range.location + match.range.length
+                    if end < source.length, Self.isLetter(source.character(at: end)) {
+                        replacement += " "
+                    }
+                }
+                result = result.replacingCharacters(in: match.range, with: replacement) as NSString
+            }
+            return result as String
+        }
+
+        private static func isLetter(_ unit: unichar) -> Bool {
+            (0x41...0x5A).contains(unit) || (0x61...0x7A).contains(unit)
+        }
+    }
+}

--- a/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Tokenizer.swift
@@ -43,10 +43,10 @@ public enum IndexTTS2TokenizerError: Error, LocalizedError, Equatable {
 ///    GPT was trained on. The vocabulary has no `▁`-prefixed CJK pieces.
 /// 3. Uppercasing of the non-CJK text.
 ///
+/// `IndexTTS2TextNormalizer` reads numbers out ahead of these steps, standing
+/// in for upstream's WeTextProcessing pass; glossary handling is not ported.
 /// Scalars without a piece become `<unk>`, with consecutive runs merged, as
-/// SentencePiece does. Upstream additionally runs a number and glossary
-/// normalizer (WeTextProcessing) before this point; this port does not, so
-/// digit runs degrade to `<unk>` and numbers should be written out as words.
+/// SentencePiece does.
 public struct IndexTTS2Tokenizer: Sendable {
     public static let maxInputScalars = 2_048
 
@@ -147,7 +147,7 @@ public struct IndexTTS2Tokenizer: Sendable {
             let unknownCount = ids.filter { $0 == unknownTokenId }.count
             if unknownCount > 0 {
                 AudioLog.inference.warning(
-                    "IndexTTS2 tokenizer mapped \(unknownCount) span(s) to <unk>; digits and unsupported symbols have no vocabulary pieces, write numbers as words.")
+                    "IndexTTS2 tokenizer mapped \(unknownCount) span(s) to <unk>; unsupported symbols have no vocabulary pieces.")
             }
         }
         return ids
@@ -182,7 +182,7 @@ public struct IndexTTS2Tokenizer: Sendable {
     // MARK: - Upstream text front end
 
     private func normalizedPieceText(for text: String) -> String {
-        let rewritten = Self.rewritePunctuation(in: text)
+        let rewritten = Self.rewritePunctuation(in: IndexTTS2TextNormalizer.normalize(text))
         let spaced = Self.separateCJKCharacters(in: rewritten).uppercased()
         let normalized = (spaced as NSString)
             .precomposedStringWithCompatibilityMapping
@@ -222,7 +222,7 @@ public struct IndexTTS2Tokenizer: Sendable {
 
     private static func rewritePunctuation(in text: String) -> String {
         let scalars = Array(text.unicodeScalars)
-        let rules = usesChineseFrontEnd(scalars) ? chinesePunctuationRewrites : punctuationRewrites
+        let rules = IndexTTS2TextNormalizer.usesChineseFrontEnd(text) ? chinesePunctuationRewrites : punctuationRewrites
         var output = String.UnicodeScalarView()
         var index = 0
         while index < scalars.count {
@@ -235,13 +235,6 @@ public struct IndexTTS2Tokenizer: Sendable {
             }
         }
         return String(output)
-    }
-
-    /// Upstream `use_chinese`: Han text, or text with no Latin letters at all.
-    private static func usesChineseFrontEnd(_ scalars: [Unicode.Scalar]) -> Bool {
-        let hasHan = scalars.contains { (0x4E00...0x9FFF).contains($0.value) }
-        let hasLatinLetter = scalars.contains { (0x41...0x5A).contains($0.value) || (0x61...0x7A).contains($0.value) }
-        return hasHan || !hasLatinLetter
     }
 
     /// Upstream `tokenize_by_CJK_char`: every CJK scalar becomes its own

--- a/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
+++ b/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
@@ -206,11 +206,15 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
         let transcript = asr.transcribe(audio: audio, sampleRate: model.sampleRate, language: language)
         let asrSec = CFAbsoluteTimeGetCurrent() - asrStart
         let asrRTF = asrSec / max(audioSec, 1e-6)
-        // CJK references carry no word boundaries; score them per character.
+        // ASR writes numbers as digits, so score both sides after the same
+        // number reading the synthesis used. CJK references carry no word
+        // boundaries; score them per character.
+        let scoredReference = IndexTTS2TextNormalizer.normalize(text)
+        let scoredHypothesis = IndexTTS2TextNormalizer.normalize(transcript)
         let usesCharacters = text.unicodeScalars.contains(where: Self.isCJK)
         let wer = usesCharacters
-            ? Self.characterErrorRate(reference: text, hypothesis: transcript)
-            : Self.wordErrorRate(reference: text, hypothesis: transcript)
+            ? Self.characterErrorRate(reference: scoredReference, hypothesis: scoredHypothesis)
+            : Self.wordErrorRate(reference: scoredReference, hypothesis: scoredHypothesis)
         let maxWER = Double(env["INDEXTTS2_E2E_MAX_WER"] ?? "") ?? 0.25
 
         print(String(format:
@@ -246,8 +250,18 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
              [11122, 10201, 10206, 10603, 10391, 10438, 10258, 10206, 10201, 10206, 11412, 10206,
               10209, 10467, 10216]),
             ("你好🙂", [10201, 208, 10201, 1260, 10201, 2]),
-            ("A2024B", [10210, 2, 10445]),
-            ("今天是2024年", [10201, 124, 10201, 1221, 10201, 2474, 10201, 2, 10201, 1698]),
+            ("A2024B", [10210, 10270, 10456, 10380, 10361, 10462]),
+            ("今天是2024年",
+             [10201, 124, 10201, 1221, 10201, 2474, 10201, 83, 10201, 6500, 10201, 83, 10201, 1017, 10201, 1698]),
+            ("今天是2024年3月5日，温度是25.5度。",
+             [10201, 124, 10201, 1221, 10201, 2474, 10201, 83, 10201, 6500, 10201, 83, 10201, 1017, 10201, 1698,
+              10201, 12, 10201, 2544, 10201, 90, 10201, 2437, 10202, 10201, 3210, 10201, 1726, 10201, 2474,
+              10201, 83, 10201, 570, 10201, 90, 10201, 3393, 10201, 90, 10201, 1726, 10203]),
+            ("The meeting is at 10:30 on the 21st.",
+             [10204, 11762, 10218, 10244, 10472, 10561, 10226, 10204, 10380, 10315, 10216]),
+            ("It costs $3.50, about 50% off.",
+             [10215, 10985, 10208, 10321, 10681, 10601, 10201, 10336, 11394, 10208, 10209, 10251, 10601, 10532,
+              10375, 10216]),
         ]
         for (text, ids) in cases {
             XCTAssertEqual(try tokenizer.encode(text), ids, "token ids for \(text)")

--- a/Tests/IndexTTS2TTSTests/IndexTTS2TTSTests.swift
+++ b/Tests/IndexTTS2TTSTests/IndexTTS2TTSTests.swift
@@ -173,16 +173,17 @@ final class IndexTTS2TTSTests: XCTestCase {
 
         // SentencePiece emits `<unk>` for uncovered scalars and merges runs.
         XCTAssertEqual(try tokenizer.encode("你好🙂"), [3, 4, 3, 5, 3, 2])
-        XCTAssertEqual(try tokenizer.encode("A2024B"), [31, 2, 33])
+        XCTAssertEqual(try tokenizer.encode("A✿B"), [31, 2, 33])
     }
 
-    func testIndexTTS2TokenizerTreatsDigitRunsAsUnknown() throws {
+    func testIndexTTS2TokenizerReadsDigitsAsNumberWords() throws {
         let tokenizer = try IndexTTS2Tokenizer(pieces: Self.mandarinPieces)
 
-        // The vocabulary has no digit pieces; upstream expands numbers with a
-        // text normalizer this port does not have yet, so a digit run must
-        // degrade to one `<unk>` rather than reject the whole input.
-        XCTAssertEqual(try tokenizer.encode("今天是2024年"), [3, 19, 3, 20, 3, 8, 3, 2, 3, 21])
+        // The vocabulary has no digit pieces, so 2024年 is read out as
+        // 二零二四年 before the lattice sees it.
+        XCTAssertEqual(
+            try tokenizer.encode("今天是2024年"),
+            [3, 19, 3, 20, 3, 8, 3, 44, 3, 45, 3, 44, 3, 46, 3, 21])
     }
 
     /// Mirrors the published `bpe.model` layout: `<s>`/`</s>`/`<unk>` at
@@ -208,6 +209,7 @@ final class IndexTTS2TTSTests: XCTestCase {
             piece("▁A", -3), piece("A", -6), piece("B", -6),
             piece(",", -5.57), piece(".", -5.98), piece("!", -9.56), piece("?", -7.77), piece("'", -5.33),
             piece("▁,", -3.28), piece("▁.", -4.06), piece("▁?", -6.21), piece("...", -8), piece("-", -11.47),
+            piece("二", 0, .userDefined), piece("零", 0, .userDefined), piece("四", 0, .userDefined),
         ]
         return pieces
     }()

--- a/Tests/IndexTTS2TTSTests/IndexTTS2TextNormalizerTests.swift
+++ b/Tests/IndexTTS2TTSTests/IndexTTS2TextNormalizerTests.swift
@@ -1,0 +1,75 @@
+@testable import IndexTTS2TTS
+import XCTest
+
+final class IndexTTS2TextNormalizerTests: XCTestCase {
+    private func normalize(_ text: String) -> String {
+        IndexTTS2TextNormalizer.normalize(text)
+    }
+
+    func testChineseCardinals() {
+        XCTAssertEqual(normalize("0个"), "零个")
+        XCTAssertEqual(normalize("10个"), "十个")
+        XCTAssertEqual(normalize("15个"), "十五个")
+        XCTAssertEqual(normalize("110个"), "一百一十个")
+        XCTAssertEqual(normalize("200个"), "二百个")
+        XCTAssertEqual(normalize("1001个"), "一千零一个")
+        XCTAssertEqual(normalize("10001个"), "一万零一个")
+        XCTAssertEqual(normalize("100000个"), "十万个")
+        XCTAssertEqual(normalize("1234567个"), "一百二十三万四千五百六十七个")
+        XCTAssertEqual(normalize("100000001个"), "一亿零一个")
+        XCTAssertEqual(normalize("一共1,000个"), "一共一千个")
+        XCTAssertEqual(normalize("编号007"), "编号零零七")
+    }
+
+    func testChineseDatesTimesAndUnits() {
+        XCTAssertEqual(normalize("今天是2024年3月5日"), "今天是二零二四年三月五日")
+        XCTAssertEqual(normalize("98年出生"), "九八年出生")
+        XCTAssertEqual(normalize("２０２４年"), "二零二四年")
+        XCTAssertEqual(normalize("10:30开会，10:05结束，11:00下班"), "十点三十分开会，十点零五分结束，十一点下班")
+        XCTAssertEqual(normalize("第1名和第2名"), "第一名和第二名")
+        XCTAssertEqual(normalize("50%折扣"), "百分之五十折扣")
+        XCTAssertEqual(normalize("圆周率是3.14"), "圆周率是三点一四")
+        XCTAssertEqual(normalize("1/2杯"), "二分之一杯")
+        XCTAssertEqual(normalize("$100和¥200"), "一百美元和二百元")
+        XCTAssertEqual(normalize("温度-5度"), "温度负五度")
+        XCTAssertEqual(normalize("电话13800138000"), "电话一三八零零一三八零零零")
+    }
+
+    func testEnglishCardinalsAndYears() {
+        XCTAssertEqual(normalize("I have 3 cats"), "I have three cats")
+        XCTAssertEqual(normalize("123456 people"), "one hundred twenty three thousand four hundred fifty six people")
+        XCTAssertEqual(normalize("1,000,000 views"), "one million views")
+        XCTAssertEqual(normalize("in 1995"), "in nineteen ninety five")
+        XCTAssertEqual(normalize("in 1900"), "in nineteen hundred")
+        XCTAssertEqual(normalize("in 1905"), "in nineteen oh five")
+        XCTAssertEqual(normalize("in 2000"), "in two thousand")
+        XCTAssertEqual(normalize("in 2005"), "in two thousand five")
+        XCTAssertEqual(normalize("in 2024"), "in twenty twenty four")
+        XCTAssertEqual(normalize("3000 units"), "three thousand units")
+        XCTAssertEqual(normalize("agent 007"), "agent zero zero seven")
+        XCTAssertEqual(normalize("A2024B"), "A two thousand twenty four B")
+    }
+
+    func testEnglishOrdinalsMoneyTimeAndPercent() {
+        XCTAssertEqual(normalize("the 21st century"), "the twenty first century")
+        XCTAssertEqual(
+            normalize("2nd, 3rd, 4th, 12th, 20th, 100th"),
+            "second, third, fourth, twelfth, twentieth, one hundredth")
+        XCTAssertEqual(normalize("50% off"), "fifty percent off")
+        XCTAssertEqual(
+            normalize("$3.50 and $1 and $0.99"),
+            "three dollars fifty cents and one dollar and ninety nine cents")
+        XCTAssertEqual(normalize("at 10:30, 10:05, 10:00"), "at ten thirty, ten oh five, ten o'clock")
+        XCTAssertEqual(normalize("pi is 3.14"), "pi is three point one four")
+        XCTAssertEqual(normalize("it was -5 degrees"), "it was minus five degrees")
+    }
+
+    func testPathSelectionAndPassThrough() {
+        // Han text, or text without Latin letters, takes the Chinese readings.
+        XCTAssertEqual(normalize("Hello 你好 2"), "Hello 你好 二")
+        XCTAssertEqual(normalize("2"), "二")
+        XCTAssertEqual(normalize("no digits here"), "no digits here")
+        XCTAssertEqual(normalize("你好"), "你好")
+        XCTAssertEqual(normalize(""), "")
+    }
+}

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -39,9 +39,11 @@ reduce speaker similarity.
 
 The tokenizer mirrors the upstream text front end: CJK punctuation is rewritten
 (`。` → `.`), every CJK character gets its own word boundary, and Latin text is
-uppercased, so Mandarin and mixed Chinese/English input work as-is. The
-vocabulary has no digit pieces and there is no number normalizer yet, so write
-numbers as words (`二零二四年`, `twenty twenty-four`); digit runs become `<unk>`.
+uppercased, so Mandarin and mixed Chinese/English input work as-is. Numbers
+are read out before tokenization (`2024年3月5日` → `二零二四年三月五日`,
+`at 10:30 on the 21st` → `at ten thirty on the twenty first`), covering
+cardinals, years, dates, times, decimals, percentages, fractions, money,
+ordinals and negatives; anything beyond that should be written as words.
 
 ## CLI
 

--- a/docs/models/indextts2.md
+++ b/docs/models/indextts2.md
@@ -76,8 +76,11 @@ published `bpe.model` and mirrors the upstream text front end ahead of it:
 a word boundary before every CJK character so the lattice emits a standalone
 `▁` ahead of each one, and Latin uppercasing. Scalars without a piece become
 `<unk>` with runs merged, as in SentencePiece. The vocabulary has no digit
-pieces and the port has no number or glossary normalizer (upstream uses
-WeTextProcessing), so digit runs degrade to `<unk>`; write numbers as words.
+pieces, so `IndexTTS2TextNormalizer` reads numbers out first — cardinals,
+years, dates, times, decimals, percentages, fractions, money, ordinals,
+negatives — in Chinese or English depending on the text. It stands in for
+upstream's WeTextProcessing pass without porting its full grammars; glossary
+handling is not ported.
 
 ## Validation Status
 
@@ -89,8 +92,8 @@ treating this port as benchmark-grade.
 
 ## Remaining Work
 
-- Number and glossary normalization (upstream WeTextProcessing); digit runs
-  currently degrade to `<unk>`.
+- Glossary handling and the long tail of WeTextProcessing number grammars
+  (units, ranges, roman numerals).
 - Upstream numerical parity checks.
 - Longer-form generation validation.
 - Public semantic sampling controls.


### PR DESCRIPTION
Follow-up to #465. The published `bpe.model` has no digit pieces, so any number in the input became `<unk>`; upstream avoids that with a WeTextProcessing pass before tokenization.

## What changed

`IndexTTS2TextNormalizer` runs ahead of punctuation rewriting and CJK pre-tokenization and reads numbers out in words. It picks the Chinese or English readings with the same predicate the tokenizer already uses (Han present, or no Latin letters at all).

- **Chinese**: cardinals with 万/亿 sections and zero-gap rules (`10001` → 一万零一, `100000` → 十万), years digit by digit (`2024年` → 二零二四年), dates, clock times (`10:05` → 十点零五分), decimals, percentages (百分之), fractions (分之), `$`/`¥` money, ordinals (第), negatives (负), thousands separators, leading-zero codes and mobile numbers digit by digit, fullwidth digits.
- **English**: cardinals up to trillions, year readings (`1995` → nineteen ninety five, `2005` → two thousand five, `2024` → twenty twenty four), ordinals (`21st` → twenty first), percentages, dollars and cents, clock times (`10:05` → ten oh five, `10:00` → ten o'clock), decimals, negatives, thousands separators, leading-zero codes digit by digit. Number words get a space when they touch a letter (`A2024B` → `A two thousand twenty four B`).

It is a compact stand-in for the common cases, not a port of the upstream FST grammars; the docs say what is covered.

## Tests

- `IndexTTS2TextNormalizerTests`: 5 tests, ~60 assertions across both paths, path selection, and pass-through.
- Tokenizer unit tests updated: digit runs now tokenize to number words; the `<unk>` test uses a non-digit symbol.
- E2E golden test extended with five number cases (Mandarin date/temperature, English time/ordinal/money/percent), all `<unk>`-free, ids cross-checked with upstream `sentencepiece` on the normalized text.
- Digit-free differential sweep (107 inputs) still identical to upstream token-for-token, so the non-number path is unchanged.
- Round trips (Qwen3-ASR, scored after the same number reading on both sides so digit-vs-word transcripts compare fairly):
  - Mandarin `今天是2024年3月5日，温度是25度。` → transcript `今天是二零二四年三月五日，温度是二十五度。`, CER 0.000
  - English `The meeting starts at 10:30 on March 21st, 2024.` → transcript `The meeting starts at 10:30 on March 21, 2024.`, WER 0.077 (the ASR wrote `21` for the spoken "twenty first")

## Regression risk

Low. Text without digits takes an early return and is untouched. Digits previously produced `<unk>` (garbage audio), so any reading is an improvement; the specific readings are pinned by tests.

## Docs

`docs/models/indextts2.md` (tokenizer paragraph, remaining work) and `docs/inference/indextts2.md` (numbers note).
