### PR TITLE
Synthesize long IndexTTS2 text segment by segment

### DIFF
--- a/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2Synthesis.swift
@@ -19,11 +19,18 @@ public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
     public var speakingRate: Float
     public var maxInternalPauseDuration: Float?
     public var s2MelSteps: Int
+    /// Longest text-token run generated in one pass; longer inputs are split
+    /// at punctuation and synthesized segment by segment, as upstream does.
+    public var maxTextTokensPerSegment: Int
+    /// Silence inserted between segments, in seconds (upstream: 0.2).
+    public var segmentIntervalSilence: Float
 
     public init(
         speakingRate: Float = 1.0,
         maxInternalPauseDuration: Float? = nil,
-        s2MelSteps: Int = 15
+        s2MelSteps: Int = 15,
+        maxTextTokensPerSegment: Int = 120,
+        segmentIntervalSilence: Float = 0.2
     ) throws {
         guard speakingRate.isFinite, speakingRate >= 0.5, speakingRate <= 1.5 else {
             throw AudioModelError.invalidConfiguration(
@@ -44,9 +51,21 @@ public struct IndexTTS2SynthesisOptions: Equatable, Sendable {
                 model: "IndexTTS2",
                 reason: "s2MelSteps must be in [4, 100].")
         }
+        guard maxTextTokensPerSegment >= 8, maxTextTokensPerSegment <= 600 else {
+            throw AudioModelError.invalidConfiguration(
+                model: "IndexTTS2",
+                reason: "maxTextTokensPerSegment must be in [8, 600].")
+        }
+        guard segmentIntervalSilence.isFinite, segmentIntervalSilence >= 0, segmentIntervalSilence <= 2.0 else {
+            throw AudioModelError.invalidConfiguration(
+                model: "IndexTTS2",
+                reason: "segmentIntervalSilence must be finite and in [0, 2.0].")
+        }
         self.speakingRate = speakingRate
         self.maxInternalPauseDuration = maxInternalPauseDuration
         self.s2MelSteps = s2MelSteps
+        self.maxTextTokensPerSegment = maxTextTokensPerSegment
+        self.segmentIntervalSilence = segmentIntervalSilence
     }
 
     public static let `default` = try! IndexTTS2SynthesisOptions()
@@ -138,6 +157,50 @@ enum IndexTTS2PauseCompressor {
 }
 
 extension IndexTTS2NativeRuntime {
+    /// Synthesizes `tokens` segment by segment (see `IndexTTS2TextSegmenter`)
+    /// and joins the pieces with `segmentIntervalSilence`, capped by
+    /// `maxInternalPauseDuration` when that is set.
+    func synthesizeSegments(
+        tokens: [IndexTTS2Token],
+        sampleRate: Int,
+        conditioning: IndexTTS2ReferenceConditioning,
+        semanticOptions: IndexTTS2SemanticGenerationOptions = IndexTTS2SemanticGenerationOptions(),
+        synthesisOptions: IndexTTS2SynthesisOptions = .default,
+        progressHandler: ((Double, String) -> Void)? = nil
+    ) throws -> [Float] {
+        let segments = IndexTTS2TextSegmenter.split(
+            tokens, maxTokens: synthesisOptions.maxTextTokensPerSegment)
+        guard !segments.isEmpty else {
+            throw AudioModelError.inferenceFailed(
+                operation: "IndexTTS2 synthesis",
+                reason: "Text produced no tokens.")
+        }
+        var gap = synthesisOptions.segmentIntervalSilence
+        if let maxPause = synthesisOptions.maxInternalPauseDuration {
+            gap = min(gap, maxPause)
+        }
+        let silence = [Float](repeating: 0, count: Int(Float(sampleRate) * gap))
+
+        var output: [Float] = []
+        for (index, segment) in segments.enumerated() {
+            progressHandler?(
+                Double(index) / Double(segments.count),
+                "IndexTTS2 synthesizing segment \(index + 1)/\(segments.count)")
+            let audio = try synthesize(
+                textTokens: segment.map(\.id),
+                conditioning: conditioning,
+                semanticOptions: semanticOptions,
+                synthesisOptions: synthesisOptions)
+            if index > 0 { output.append(contentsOf: silence) }
+            output.append(contentsOf: audio)
+            // Each segment leaves its intermediates in the MLX buffer cache;
+            // release them so long inputs stay within a bounded footprint.
+            Memory.clearCache()
+        }
+        progressHandler?(1.0, "IndexTTS2 synthesis complete")
+        return output
+    }
+
     func synthesize(
         textTokens: [Int],
         conditioning: IndexTTS2ReferenceConditioning,

--- a/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2TTSModel.swift
@@ -236,8 +236,9 @@ public final class IndexTTS2TTSModel: SpeechGenerationModel, ModelMemoryManageab
                 operation: "IndexTTS2 synthesis",
                 reason: "Tokenizer could not be initialized from bpe.model.")
         }
-        return try runtime().synthesize(
-            textTokens: try tokenizer.encode(text),
+        return try runtime().synthesizeSegments(
+            tokens: try tokenizer.tokenize(text),
+            sampleRate: sampleRate,
             conditioning: conditioning,
             semanticOptions: semanticOptions,
             synthesisOptions: synthesisOptions)
@@ -319,7 +320,7 @@ public final class IndexTTS2TTSModel: SpeechGenerationModel, ModelMemoryManageab
                 operation: "IndexTTS2 synthesis",
                 reason: "Tokenizer could not be initialized from bpe.model.")
         }
-        let textTokens = try tokenizer.encode(text)
+        let tokens = try tokenizer.tokenize(text)
         var stageStart = CFAbsoluteTimeGetCurrent()
         let runtime = try runtime()
         IndexTTS2StageTimer.report("runtime-load", since: &stageStart)
@@ -328,8 +329,9 @@ public final class IndexTTS2TTSModel: SpeechGenerationModel, ModelMemoryManageab
             emotionReferenceAudio: emotionReferenceAudio,
             emotionControl: emotionControl)
         IndexTTS2StageTimer.report("reference-conditioning", since: &stageStart)
-        return try runtime.synthesize(
-            textTokens: textTokens,
+        return try runtime.synthesizeSegments(
+            tokens: tokens,
+            sampleRate: sampleRate,
             conditioning: conditioning,
             synthesisOptions: synthesisOptions)
     }

--- a/Sources/IndexTTS2TTS/IndexTTS2TextSegmenter.swift
+++ b/Sources/IndexTTS2TTS/IndexTTS2TextSegmenter.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Splits a tokenized sentence into synthesis segments the way upstream
+/// `TextTokenizer.split_segments` does: cut after sentence-final punctuation,
+/// commas and hyphens, then merge neighbouring runs back together while they
+/// still fit in `maxTokens`. Each segment is generated on its own so long
+/// inputs never exceed the GPT's text window or its mel budget.
+///
+/// One deliberate difference: upstream chops a punctuation-free run at the
+/// limit and leaves the remainder as its own segment, which can be a single
+/// token (even a lone `▁`) and synthesizes as noise. Such runs are cut into
+/// even chunks here, preferring word boundaries.
+struct IndexTTS2TextSegmenter {
+    static let defaultMaxTokens = 120
+
+    private static let sentenceEndPieces: Set<String> = [".", "!", "?", "▁.", "▁?", "▁..."]
+    private static let commaPieces: Set<String> = [",", "▁,"]
+    private static let hyphenPieces: Set<String> = ["-"]
+    private static let apostrophePieces: Set<String> = ["'", "▁'"]
+
+    static func split(_ tokens: [IndexTTS2Token], maxTokens: Int = defaultMaxTokens) -> [[IndexTTS2Token]] {
+        guard !tokens.isEmpty else { return [] }
+        let limit = max(1, maxTokens)
+
+        var runs: [[IndexTTS2Token]] = []
+        var current: [IndexTTS2Token] = []
+        var index = 0
+        while index < tokens.count {
+            let token = tokens[index]
+            current.append(token)
+            index += 1
+
+            if commaPieces.contains(token.piece) || hyphenPieces.contains(token.piece) {
+                runs.append(current)
+                current = []
+            } else if sentenceEndPieces.contains(token.piece), current.count > 2 {
+                // Keep a trailing apostrophe with the sentence it closes.
+                if index < tokens.count, apostrophePieces.contains(tokens[index].piece) {
+                    current.append(tokens[index])
+                    index += 1
+                }
+                runs.append(current)
+                current = []
+            }
+        }
+        if !current.isEmpty { runs.append(current) }
+
+        let bounded = runs.flatMap { chunkEvenly($0, limit: limit) }
+
+        var merged: [[IndexTTS2Token]] = []
+        for run in bounded {
+            if let last = merged.last, last.count + run.count <= limit {
+                merged[merged.count - 1] = last + run
+            } else {
+                merged.append(run)
+            }
+        }
+        return merged
+    }
+
+    /// Cuts a run longer than `limit` into near-equal chunks, moving each cut
+    /// back to the nearest word start (a `▁`-prefixed piece) when that keeps
+    /// the chunk at least half the target size.
+    private static func chunkEvenly(_ run: [IndexTTS2Token], limit: Int) -> [[IndexTTS2Token]] {
+        guard run.count > limit else { return [run] }
+        let chunkCount = (run.count + limit - 1) / limit
+        let target = (run.count + chunkCount - 1) / chunkCount
+
+        var chunks: [[IndexTTS2Token]] = []
+        var start = 0
+        while start < run.count {
+            var end = min(start + target, run.count)
+            if end < run.count {
+                var boundary = end
+                while boundary > start + target / 2, !run[boundary].piece.hasPrefix("▁") {
+                    boundary -= 1
+                }
+                if boundary > start { end = boundary }
+            }
+            chunks.append(Array(run[start..<end]))
+            start = end
+        }
+        return chunks
+    }
+}

--- a/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
+++ b/Tests/IndexTTS2TTSTests/E2EIndexTTS2BundleTests.swift
@@ -2,6 +2,7 @@ import AudioCommon
 import Darwin
 import Foundation
 @testable import IndexTTS2TTS
+import MLX
 @testable import Qwen3ASR
 import XCTest
 
@@ -279,6 +280,53 @@ final class E2EIndexTTS2BundleTests: XCTestCase {
         }
         let model = try await loadModel()
         return try XCTUnwrap(model.tokenizer, "bundle tokenizer failed to initialize")
+    }
+
+    private static let defaultLongText =
+        "The quick brown fox jumps over the lazy dog near the river bank. "
+        + "Every morning the baker opens the shop before sunrise and sets out fresh bread. "
+        + "Later in the day the children walk home from school along the same road. "
+        + "By evening the whole street smells of coffee and rain."
+
+    func testLongTextSynthesisSplitsIntoSegments() async throws {
+        let model = try await loadModel()
+        let env = ProcessInfo.processInfo.environment
+        let referenceURL = try benchmarkReferenceURL(env: env)
+        let text = env["INDEXTTS2_E2E_LONG_TEXT"] ?? Self.defaultLongText
+        let options = try IndexTTS2SynthesisOptions(
+            maxInternalPauseDuration: Float(env["INDEXTTS2_E2E_MAX_PAUSE"] ?? ""),
+            maxTextTokensPerSegment: Int(env["INDEXTTS2_E2E_SEGMENT_TOKENS"] ?? "") ?? 30)
+        let tokenizer = try XCTUnwrap(model.tokenizer)
+        let segments = IndexTTS2TextSegmenter.split(
+            try tokenizer.tokenize(text), maxTokens: options.maxTextTokensPerSegment)
+        XCTAssertGreaterThanOrEqual(segments.count, 3, "long text should split into several segments")
+
+        _ = try model.prepareRuntime()
+        let conditioning = try model.prepareReferenceConditioning(referenceAudio: referenceURL)
+        let start = CFAbsoluteTimeGetCurrent()
+        let audio = try model.synthesize(text: text, conditioning: conditioning, synthesisOptions: options)
+        let synthesisSec = CFAbsoluteTimeGetCurrent() - start
+        let audioSec = Double(audio.count) / Double(model.sampleRate)
+        XCTAssertGreaterThan(audioSec, 8)
+        XCTAssertTrue(audio.allSatisfy(\.isFinite))
+        if let output = env["INDEXTTS2_E2E_OUTPUT"], !output.isEmpty {
+            try WAVWriter.write(samples: audio, sampleRate: model.sampleRate, to: URL(fileURLWithPath: output))
+        }
+        print(String(format: "[IndexTTS2LongText] segments=%d audioSec=%.2f synthesisSec=%.1f rtf=%.2f",
+                     segments.count, audioSec, synthesisSec, synthesisSec / max(audioSec, 1e-6)))
+
+        guard env["INDEXTTS2_E2E_ROUNDTRIP"] == "1" else { return }
+        Memory.clearCache()
+        let asr = try await Qwen3ASRModel.fromPretrained(
+            modelId: env["INDEXTTS2_E2E_ASR_MODEL"] ?? Self.defaultQwenASRModelId)
+        let language = env["INDEXTTS2_E2E_LANGUAGE"] ?? "english"
+        let transcript = asr.transcribe(audio: audio, sampleRate: model.sampleRate, language: language)
+        let usesCharacters = text.unicodeScalars.contains(where: Self.isCJK)
+        let wer = usesCharacters
+            ? Self.characterErrorRate(reference: text, hypothesis: transcript)
+            : Self.wordErrorRate(reference: text, hypothesis: transcript)
+        print(String(format: "[IndexTTS2LongTextRoundtrip] transcript=\"%@\" wer=%.3f", transcript, wer))
+        XCTAssertLessThanOrEqual(wer, Double(env["INDEXTTS2_E2E_MAX_WER"] ?? "") ?? 0.25)
     }
 
     private func loadModel() async throws -> IndexTTS2TTSModel {

--- a/Tests/IndexTTS2TTSTests/IndexTTS2TextSegmenterTests.swift
+++ b/Tests/IndexTTS2TTSTests/IndexTTS2TextSegmenterTests.swift
@@ -1,0 +1,64 @@
+@testable import IndexTTS2TTS
+import XCTest
+
+final class IndexTTS2TextSegmenterTests: XCTestCase {
+    private func tokens(_ pieces: String...) -> [IndexTTS2Token] {
+        pieces.enumerated().map { IndexTTS2Token(id: $0.offset, piece: $0.element) }
+    }
+
+    private func pieces(_ segments: [[IndexTTS2Token]]) -> [[String]] {
+        segments.map { $0.map(\.piece) }
+    }
+
+    func testShortTextStaysOneSegment() {
+        let input = tokens("▁HELLO", ",", "▁WORLD", ".", "▁HOW", "▁ARE", "▁YOU", "?")
+        XCTAssertEqual(pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 120)), [input.map(\.piece)])
+    }
+
+    func testSentencesSplitWhenTheyDoNotFitTogether() {
+        let input = tokens("▁A", "▁B", "▁C", ".", "▁D", "▁E", "▁F", "?", "▁G", "▁H", "!")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 8)),
+            [["▁A", "▁B", "▁C", ".", "▁D", "▁E", "▁F", "?"], ["▁G", "▁H", "!"]])
+    }
+
+    func testCommasAndHyphensAreFallbackCuts() {
+        let input = tokens("▁A", "▁B", ",", "▁C", "▁D", "-", "▁E", "▁F", ".")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 4)),
+            [["▁A", "▁B", ","], ["▁C", "▁D", "-"], ["▁E", "▁F", "."]])
+    }
+
+    func testPunctuationFreeRunIsChunkedAtTheLimit() {
+        let input = tokens("▁", "你", "▁", "好", "▁", "世", "▁", "界", "▁", "是")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 4)),
+            [["▁", "你", "▁", "好"], ["▁", "世", "▁", "界"], ["▁", "是"]])
+    }
+
+    func testLengthCutsPreferWordBoundaries() {
+        let input = tokens("▁A", "B", "▁C", "D", "▁E", "F")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 4)),
+            [["▁A", "B", "▁C", "D"], ["▁E", "F"]])
+    }
+
+    func testTrailingApostropheStaysWithItsSentence() {
+        let input = tokens("▁HE", "▁SAID", "▁'", "HI", ".", "'", "▁THEN", "▁LEFT", ".")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 6)),
+            [["▁HE", "▁SAID", "▁'", "HI", ".", "'"], ["▁THEN", "▁LEFT", "."]])
+    }
+
+    func testVeryShortSentenceDoesNotCloseASegment() {
+        // Upstream only cuts at sentence punctuation once a run has more than two tokens.
+        let input = tokens("▁OK", ".", "▁THEN", "▁WE", "▁GO", ".")
+        XCTAssertEqual(
+            pieces(IndexTTS2TextSegmenter.split(input, maxTokens: 120)),
+            [["▁OK", ".", "▁THEN", "▁WE", "▁GO", "."]])
+    }
+
+    func testEmptyInput() {
+        XCTAssertEqual(IndexTTS2TextSegmenter.split([], maxTokens: 120).count, 0)
+    }
+}

--- a/docs/inference/indextts2.md
+++ b/docs/inference/indextts2.md
@@ -37,6 +37,15 @@ For identity-first cloning, omit explicit emotion control and use
 `IndexTTS2SynthesisOptions` for tempo and pause shaping. High emotion weights can
 reduce speaker similarity.
 
+Long text is synthesized segment by segment, as upstream does: the token
+sequence is cut after sentence-final punctuation (then commas and hyphens,
+then by length), neighbouring runs are merged back up to
+`maxTextTokensPerSegment` (default 120), each segment is generated on its own,
+and the pieces are joined with `segmentIntervalSilence` (default 0.2 s, capped
+by `maxInternalPauseDuration` when set). `generate(text:referenceAudio:…)` and
+`synthesize(text:conditioning:semanticOptions:synthesisOptions:)` take this
+path; the semantic-code entry points still generate one sequence.
+
 The tokenizer mirrors the upstream text front end: CJK punctuation is rewritten
 (`。` → `.`), every CJK character gets its own word boundary, and Latin text is
 uppercased, so Mandarin and mixed Chinese/English input work as-is. Numbers

--- a/docs/models/indextts2.md
+++ b/docs/models/indextts2.md
@@ -95,6 +95,6 @@ treating this port as benchmark-grade.
 - Glossary handling and the long tail of WeTextProcessing number grammars
   (units, ranges, roman numerals).
 - Upstream numerical parity checks.
-- Longer-form generation validation.
+- Longer-form listening checks beyond the segmented ASR round trip.
 - Public semantic sampling controls.
 - Subjective listening plus ASR roundtrip checks across the benchmark languages.


### PR DESCRIPTION
Follow-up to #465 and #467 (stacked on #467). Upstream IndexTTS2 never feeds the GPT more than `max_text_tokens_per_segment` (120) text tokens at once; it splits the input at punctuation, synthesizes each segment, and joins the audio with a short silence. This port fed the whole sequence in one pass, which matters more now that per-character `▁` doubles Mandarin token counts.

## What changed

- `IndexTTS2TextSegmenter` mirrors upstream `split_segments`: cut after sentence-final punctuation (`.` `!` `?` `▁.` `▁?` `▁...`, keeping a trailing apostrophe), commas and hyphens, then greedily merge neighbouring runs back up to the limit. One deliberate difference: upstream chops a punctuation-free run at the limit and leaves the remainder as its own segment — which can be a single token, even a lone `▁`, and synthesizes as noise. Such runs are cut into even chunks here, preferring word boundaries.
- `IndexTTS2SynthesisOptions` gains `maxTextTokensPerSegment` (default 120, range 8–600) and `segmentIntervalSilence` (default 0.2 s like upstream, capped by `maxInternalPauseDuration` when that is set).
- `IndexTTS2NativeRuntime.synthesizeSegments` generates each segment with the same conditioning, joins the pieces, and clears the MLX buffer cache after each segment so long inputs stay within a bounded footprint (an 8-segment Mandarin run followed by an ASR model load hit a Metal out-of-memory without this). `generate(text:referenceAudio:…)` and `synthesize(text:conditioning:semanticOptions:synthesisOptions:)` — and therefore the CLI — take this path. The semantic-code entry points (`generateSemanticCodes`, `synthesize(text:conditioning:semantic:)`) still produce one sequence, so the benchmark and seed-sweep tooling is unchanged.

## Tests

- `IndexTTS2TextSegmenterTests`: 8 tests — short text stays whole, sentence cuts when they don't fit, comma/hyphen fallbacks, even chunking of punctuation-free runs, word-boundary preference, apostrophe handling, the >2-token rule, empty input.
- `E2EIndexTTS2BundleTests/testLongTextSynthesisSplitsIntoSegments`: four-sentence text with a 30-token limit, asserts ≥3 segments and finite audio, and with `INDEXTTS2_E2E_ROUNDTRIP=1` scores the ASR transcript (`INDEXTTS2_E2E_LONG_TEXT`, `INDEXTTS2_E2E_SEGMENT_TOKENS`, `INDEXTTS2_E2E_LANGUAGE` override the defaults). Results:
  - English (default text, 30-token limit): 4 segments, 14.2 s of audio, WER 0.039
  - Mandarin (four sentences, `zh`): 8 segments, 19.7 s of audio, transcript character-exact, CER 0.000

## Regression risk

Short inputs (under 120 tokens) produce exactly one segment, so the existing single-pass behaviour and all earlier round trips are unchanged. Long inputs previously ran in one pass up to `maxTextTokens` 600 and could exhaust the mel budget; they now match upstream's structure.

## Docs

`docs/inference/indextts2.md` (segmentation paragraph) and `docs/models/indextts2.md` (remaining work).
