### PR TITLE
Add custom pronunciation injection to the Kokoro phonemizer

### DIFF
--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -144,6 +144,12 @@ public final class KokoroTTSModel {
     /// space, hyphen, or apostrophe is never looked up, because text is split on
     /// punctuation before resolution. The IPA must use symbols from the model
     /// vocabulary; anything else is dropped at tokenization.
+    ///
+    /// Entries apply to English only. Passing `language:` zh, ja, it, fr, es, pt,
+    /// or hi to `synthesize` selects a phonemizer that never sees them.
+    ///
+    /// The lookup is unlocked, so register entries before `synthesize` starts
+    /// running concurrently on this instance.
     public func addPronunciations(_ entries: [String: String]) {
         phonemizer.addPronunciations(entries)
     }

--- a/Sources/KokoroTTS/KokoroTTS.swift
+++ b/Sources/KokoroTTS/KokoroTTS.swift
@@ -136,6 +136,18 @@ public final class KokoroTTSModel {
         Array(voiceEmbeddings.keys).sorted()
     }
 
+    /// Registers custom `word -> IPA` pronunciations for proper nouns missing from
+    /// the shipped dictionaries. Resolved ahead of the bundled dictionaries, suffix
+    /// stemming, and the neural G2P fallback.
+    ///
+    /// Keys are matched lowercased and must be single words — a key containing a
+    /// space, hyphen, or apostrophe is never looked up, because text is split on
+    /// punctuation before resolution. The IPA must use symbols from the model
+    /// vocabulary; anything else is dropped at tokenization.
+    public func addPronunciations(_ entries: [String: String]) {
+        phonemizer.addPronunciations(entries)
+    }
+
     // MARK: - Helpers
 
     private func createInt32Array(shape: [Int], values: [Int32]) throws -> MLMultiArray {

--- a/Sources/KokoroTTS/Phonemizer.swift
+++ b/Sources/KokoroTTS/Phonemizer.swift
@@ -110,6 +110,13 @@ public final class KokoroPhonemizer {
     /// IPA must use symbols present in the model vocabulary — unknown characters
     /// are silently dropped by `tokenize`.
     ///
+    /// English only. `tokenize` routes zh, ja, it, fr, es, pt, and hi to their
+    /// own phonemizers, none of which consult `goldDict`, so entries added here
+    /// are a no-op for those languages.
+    ///
+    /// Not synchronized: `tokenize` reads `goldDict` without a lock, so register
+    /// entries before synthesis starts running concurrently.
+    ///
     /// Call this after `loadDictionaries(from:)`, which replaces the gold
     /// dictionary wholesale and would discard entries added before it.
     public func addPronunciations(_ entries: [String: String]) {

--- a/Sources/KokoroTTS/Phonemizer.swift
+++ b/Sources/KokoroTTS/Phonemizer.swift
@@ -94,6 +94,30 @@ public final class KokoroPhonemizer {
         }
     }
 
+    /// Injects custom `word -> IPA` pronunciations into the gold dictionary.
+    ///
+    /// `resolveWord` consults `goldDict` before the silver dict, stemming, and the
+    /// neural `bartG2P` fallback, so entries added here take precedence over all
+    /// three. Proper nouns absent from the shipped dictionaries are otherwise
+    /// guessed from *English* spelling rules and come out badly wrong for
+    /// non-Anglo names. The function words in `specialCase` — the, a, an, to, of,
+    /// i — resolve earlier still and cannot be overridden this way.
+    ///
+    /// Keys are matched lowercased and must be single words: text is split on
+    /// whitespace and punctuation before resolution, so a key containing a space,
+    /// hyphen, or apostrophe is never looked up. Register the parts separately.
+    ///
+    /// IPA must use symbols present in the model vocabulary — unknown characters
+    /// are silently dropped by `tokenize`.
+    ///
+    /// Call this after `loadDictionaries(from:)`, which replaces the gold
+    /// dictionary wholesale and would discard entries added before it.
+    public func addPronunciations(_ entries: [String: String]) {
+        for (word, ipa) in entries {
+            goldDict[word.lowercased()] = .simple(ipa)
+        }
+    }
+
     /// Load separate G2P encoder + decoder CoreML models.
     public func loadG2PModels(encoderURL: URL, decoderURL: URL, vocabURL: URL) throws {
         let config = MLModelConfiguration()

--- a/Tests/KokoroTTSTests/KokoroE2ETests.swift
+++ b/Tests/KokoroTTSTests/KokoroE2ETests.swift
@@ -129,4 +129,30 @@ final class E2EKokoroTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(matchedPhrases.count, 1,
             "At least 1 of \(expectedPhrases) should appear in: \"\(transcription)\"")
     }
+
+    // MARK: - Custom Pronunciations
+
+    /// The neural `bartG2P` fallback guesses from *English* spelling rules, so
+    /// names outside the shipped dictionaries come out wrong. Proves an injected
+    /// entry is resolved instead of that guess — the unit tests in
+    /// `KokoroPronunciationTests` can only pin the resolution order, because
+    /// `bartG2P` needs the downloaded CoreML G2P models.
+    func testCustomPronunciationBeatsNeuralG2P() async throws {
+        let m = try await model()
+        let target = "tɑtiˈɑnə"   // "tah-tee-AH-nuh"
+
+        let guessed = m.phonemizer.textToPhonemes("Tatiana")
+        print("bartG2P guess:            \"\(guessed)\"")
+        XCTAssertNotEqual(guessed, "tatiana",
+            "Expected a phonemic guess from bartG2P, not the raw-letter last resort")
+        XCTAssertNotEqual(guessed, target,
+            "The name must not already resolve correctly, or the test proves nothing")
+
+        m.addPronunciations(["tatiana": target])
+
+        let injected = m.phonemizer.textToPhonemes("Tatiana")
+        print("after addPronunciations:  \"\(injected)\"")
+        XCTAssertEqual(injected, target,
+            "Injected entry must be resolved ahead of the neural G2P fallback")
+    }
 }

--- a/Tests/KokoroTTSTests/KokoroTTSTests.swift
+++ b/Tests/KokoroTTSTests/KokoroTTSTests.swift
@@ -527,4 +527,25 @@ final class KokoroPronunciationTests: XCTestCase {
         XCTAssertEqual(phonemizer.tokenize("Tatiana"),
             [phonemizer.bosId, 7, 8, 7, 5, phonemizer.eosId])
     }
+
+    /// Documented constraint: only the English path consults the dictionaries.
+    /// `tokenize` routes every other language to a dedicated phonemizer, so an
+    /// injected entry is a no-op there.
+    func testInjectionAppliesToEnglishOnly() {
+        let others = ["fr", "es", "it", "pt", "hi", "ja", "zh"]
+        let phonemizer = makePhonemizer()
+        let baseline = others.map { phonemizer.tokenize("Tatiana", language: $0) }
+
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+
+        let vocab = makeVocab()
+        XCTAssertEqual(phonemizer.tokenize("Tatiana", language: "en"),
+            [phonemizer.bosId] + tatianaIPA.compactMap { vocab[String($0)] } + [phonemizer.eosId],
+            "English must resolve the injected entry")
+
+        for (language, before) in zip(others, baseline) {
+            XCTAssertEqual(phonemizer.tokenize("Tatiana", language: language), before,
+                "\"\(language)\" must be unaffected by the injected entry")
+        }
+    }
 }

--- a/Tests/KokoroTTSTests/KokoroTTSTests.swift
+++ b/Tests/KokoroTTSTests/KokoroTTSTests.swift
@@ -372,3 +372,159 @@ final class MultilingualTokenizerTests: XCTestCase {
         XCTAssertEqual(idsDefault, idsEn, "Default should route to English")
     }
 }
+
+// MARK: - Custom Pronunciation Tests
+
+/// `addPronunciations` writes into the gold dictionary, which `resolveWord`
+/// consults before the silver dict, suffix stemming, and the neural `bartG2P`
+/// fallback. These tests pin that ordering without loading the CoreML G2P
+/// models: with no models loaded `bartG2P` returns nil, so resolution falls
+/// through to the raw-letter last resort, which stands in for it here.
+/// `E2EKokoroTests.testCustomPronunciationBeatsNeuralG2P` covers the real
+/// neural fallback with downloaded weights.
+final class KokoroPronunciationTests: XCTestCase {
+
+    /// "tah-tee-AH-nuh" — a name absent from both shipped dictionaries.
+    private let tatianaIPA = "tɑtiˈɑnə"
+
+    /// Covers the IPA symbols used below plus the plain letters the raw-letter
+    /// fallback emits, so tokenization round-trips either outcome.
+    private func makeVocab() -> [String: Int] {
+        ["<pad>": 0, "<bos>": 1, "<eos>": 2,
+         "a": 3, "e": 4, "i": 5, "n": 6, "t": 7,
+         "ɑ": 8, "ə": 9, "æ": 10, "ˈ": 11, " ": 12]
+    }
+
+    private func makePhonemizer() -> KokoroPhonemizer {
+        KokoroPhonemizer(vocab: makeVocab())
+    }
+
+    /// Writes a minimal `us_gold.json` to a temp directory and loads it.
+    private func loadGoldDictionary(
+        _ entries: [String: String], into phonemizer: KokoroPhonemizer
+    ) throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+
+        let data = try JSONSerialization.data(withJSONObject: entries)
+        try data.write(to: dir.appendingPathComponent("us_gold.json"))
+        try phonemizer.loadDictionaries(from: dir)
+    }
+
+    /// The motivating case: a word in neither dictionary reaches the G2P
+    /// fallback, and an injected entry pre-empts it.
+    func testInjectedEntryPreemptsFallback() {
+        let phonemizer = makePhonemizer()
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), "tatiana",
+            "With no dictionaries and no G2P models, resolution falls through to raw letters")
+
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), tatianaIPA,
+            "Injected entry must be resolved instead of the fallback")
+    }
+
+    /// An injected entry outranks a shipped gold entry, so a caller can correct
+    /// a dictionary pronunciation rather than only fill a gap.
+    func testInjectedEntryOverridesGoldDictionary() throws {
+        let phonemizer = makePhonemizer()
+        try loadGoldDictionary(["tatiana": "tætiænə"], into: phonemizer)
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), "tætiænə")
+
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), tatianaIPA,
+            "Injected entry must outrank the shipped gold entry")
+    }
+
+    /// Entries are stored lowercased and `resolveWord` lowercases the word, so
+    /// capitalization on either side is irrelevant — proper nouns arrive
+    /// capitalized in real text.
+    func testLookupIsCaseInsensitive() {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations(["TaTiAnA": tatianaIPA])
+
+        for spelling in ["tatiana", "Tatiana", "TATIANA"] {
+            XCTAssertEqual(phonemizer.textToPhonemes(spelling), tatianaIPA,
+                "\"\(spelling)\" should resolve to the injected pronunciation")
+        }
+    }
+
+    /// A later call replaces an earlier entry for the same word, and leaves the
+    /// other entries alone.
+    func testLaterCallReplacesEarlierEntry() {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations(["tatiana": "tætiænə", "tania": "ˈtɑniə"])
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+
+        XCTAssertEqual(phonemizer.textToPhonemes("tatiana"), tatianaIPA)
+        XCTAssertEqual(phonemizer.textToPhonemes("tania"), "ˈtɑniə",
+            "Unrelated entries must survive a later call")
+    }
+
+    /// Behaviour end to end: the injected IPA reaches the token ids the model
+    /// is fed, wrapped in BOS/EOS.
+    func testInjectedPronunciationSurvivesTokenization() {
+        let phonemizer = makePhonemizer()
+        let vocab = makeVocab()
+        let before = phonemizer.tokenize("Tatiana")
+
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+        let after = phonemizer.tokenize("Tatiana")
+
+        let expected = [phonemizer.bosId] + tatianaIPA.compactMap { vocab[String($0)] }
+            + [phonemizer.eosId]
+        XCTAssertEqual(after, expected)
+        XCTAssertNotEqual(after, before, "Token ids must change once a pronunciation is injected")
+    }
+
+    /// Documented constraint: text is split on whitespace and punctuation before
+    /// resolution, so a key spanning more than one token is never looked up.
+    func testMultiTokenKeysAreNeverMatched() {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations([
+            "ana maria": "ˈɑnəməˈɹiə",
+            "ana-maria": "ˈɑnəməˈɹiə",
+        ])
+
+        XCTAssertEqual(phonemizer.textToPhonemes("Ana Maria"), "ana maria",
+            "A key containing a space cannot be reached")
+        XCTAssertEqual(phonemizer.textToPhonemes("Ana-Maria"), "ana-maria",
+            "A key containing a hyphen cannot be reached")
+    }
+
+    /// Documented constraint: `specialCase` resolves before the dictionaries, so
+    /// its function words are not overridable.
+    func testSpecialCaseWordsAreNotOverridden() {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations(["the": "ðiː", "of": "ɒv"])
+
+        XCTAssertEqual(phonemizer.textToPhonemes("the"), "ðə")
+        XCTAssertEqual(phonemizer.textToPhonemes("of"), "ʌv")
+    }
+
+    /// Documented constraint: `loadDictionaries` assigns the gold dictionary
+    /// rather than merging into it, so injections must come afterwards.
+    func testLoadingDictionariesDiscardsEarlierInjections() throws {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations(["tatiana": tatianaIPA])
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), tatianaIPA)
+
+        try loadGoldDictionary(["hello": "həlˈoʊ"], into: phonemizer)
+
+        XCTAssertEqual(phonemizer.textToPhonemes("Tatiana"), "tatiana",
+            "Entries injected before loadDictionaries do not survive it")
+    }
+
+    /// IPA symbols outside the model vocabulary are dropped at tokenization
+    /// (documented on the API), not rejected — the rest still tokenizes.
+    func testSymbolsOutsideVocabularyAreDropped() {
+        let phonemizer = makePhonemizer()
+        phonemizer.addPronunciations(["tatiana": "tɑ↗ti"])
+
+        XCTAssertEqual(phonemizer.tokenize("Tatiana"),
+            [phonemizer.bosId, 7, 8, 7, 5, phonemizer.eosId])
+    }
+}

--- a/docs/models/kokoro-tts.md
+++ b/docs/models/kokoro-tts.md
@@ -123,6 +123,17 @@ Three-tier pipeline, all Apache-2.0 licensed (no GPL dependencies):
 2. **Suffix stemming** — Morphological decomposition for known suffixes
 3. **BART G2P** — Neural grapheme-to-phoneme fallback using a separate CoreML encoder-decoder model for OOV words
 
+### Custom pronunciations
+
+Proper nouns outside the shipped dictionaries reach the BART G2P fallback, which guesses from *English* spelling rules and mangles non-Anglo names. `addPronunciations` injects `word -> IPA` entries ahead of tier 1:
+
+```swift
+let tts = try await KokoroTTSModel.fromPretrained()
+tts.addPronunciations(["tatiana": "tɑtiˈɑnə"])
+```
+
+Keys are matched lowercased and must be single words — text is split on whitespace and punctuation before resolution, so a key containing a space, hyphen, or apostrophe is never looked up. IPA must use symbols from the model vocabulary; anything else is silently dropped at tokenization. Call `addPronunciations` after the dictionaries are loaded — `loadDictionaries` replaces the gold dictionary wholesale.
+
 ## Voice Embeddings
 
 Each voice is a 256-dimensional Float32 vector stored in a per-voice JSON file. The embedding captures speaker identity and style characteristics. The first 128 dimensions are used by the decoder, the second 128 by the prosody model.

--- a/docs/models/kokoro-tts.md
+++ b/docs/models/kokoro-tts.md
@@ -134,6 +134,8 @@ tts.addPronunciations(["tatiana": "tɑtiˈɑnə"])
 
 Keys are matched lowercased and must be single words — text is split on whitespace and punctuation before resolution, so a key containing a space, hyphen, or apostrophe is never looked up. IPA must use symbols from the model vocabulary; anything else is silently dropped at tokenization. Call `addPronunciations` after the dictionaries are loaded — `loadDictionaries` replaces the gold dictionary wholesale.
 
+Entries apply to the English path only: the `language` argument selects a dedicated phonemizer for Chinese, Japanese, Italian, French, Spanish, Portuguese, and Hindi, and none of those consult the gold dictionary. The lookup is unlocked, so register entries before synthesis starts running concurrently on the same model.
+
 ## Voice Embeddings
 
 Each voice is a 256-dimensional Float32 vector stored in a per-voice JSON file. The embedding captures speaker identity and style characteristics. The first 128 dimensions are used by the decoder, the second 128 by the prosody model.


### PR DESCRIPTION
## Summary

- Add `addPronunciations(_:)` to `KokoroPhonemizer` and forward it from `KokoroTTSModel`, so a caller can inject `word -> IPA` entries that resolve ahead of the bundled dictionaries.
- Unit tests pinning the resolution order, plus an E2E test against the real neural G2P fallback.
- Short **Custom pronunciations** section in `docs/models/kokoro-tts.md`.

229 added lines, no deletions. The public API is two functions; the rest is tests and docs.

## Why

`resolveWord` resolves English through `specialCase` → `goldDict` → `silverDict` → `stemAndLookup` → `bartG2P` → raw letters. A word in neither dictionary reaches `bartG2P`, which guesses from *English* spelling rules. That is the right behaviour for OOV English words and the wrong one for non-Anglo proper nouns:

```
"Tatiana" → bartG2P → tˈitiəniənə
```

Checking the shipped dictionaries (`us_gold.json`, 90,217 entries; `us_silver.json`, 93,492):

| Present | Absent from both |
|---|---|
| `john`, `anna`, `maria`, `emma`, `sarah` | `tatiana`, `olga`, `dmitri`, `yulia`, `oksana`, `svetlana`, `natalia`, `siobhan`, `xochitl` |

An application generally knows which names its users care about, but `KokoroTTSModel.phonemizer` is `internal`, so there is no way to supply them short of forking. #184 established dictionary-first phonemization for the shipped word lists; this extends the same idea to caller-supplied words.

Entries go into the gold dictionary rather than silver, so an injected pronunciation also outranks a shipped entry — one call both fills a gap and corrects a wrong dictionary pronunciation.

```swift
let tts = try await KokoroTTSModel.fromPretrained()
tts.addPronunciations(["tatiana": "tɑtiˈɑnə"])
```

## Tests

`KokoroPronunciationTests` (unit, no downloads) covers an injected entry pre-empting the fallback, overriding a loaded gold entry, case-insensitive keys, replacement by a later call, and tokenization of the injected IPA. With no G2P models loaded `bartG2P` returns `nil`, so these pin the resolution order rather than the neural path.

Three of them are characterization tests for constraints the doc comments now state, so the behaviour can't drift silently: out-of-vocabulary IPA symbols are dropped, keys spanning more than one token are unreachable (text is split on whitespace and punctuation before resolution), and the `specialCase` function words resolve ahead of any dictionary.

`E2EKokoroTests.testCustomPronunciationBeatsNeuralG2P` covers the neural path with real weights: it asserts the model produces a phonemic guess for a name absent from the dictionaries, then that the injected entry replaces it.

```
$ swift test --skip-build --filter KokoroPronunciationTests
Test Suite 'KokoroPronunciationTests' passed
     Executed 9 tests, with 0 failures (0 unexpected) in 0.211 seconds

$ swift test --skip-build --filter E2EKokoroTests/testCustomPronunciationBeatsNeuralG2P
Test Case '-[KokoroTTSTests.E2EKokoroTests testCustomPronunciationBeatsNeuralG2P]' passed (22.440 seconds)
bartG2P guess:            "tˈitiəniənə"
after addPronunciations:  "tɑtiˈɑnə"
```

Two notes for reviewers:

- `tests.yml` passes `--skip KokoroTTSTests`, so neither suite runs in PR CI. Both were run locally on Apple silicon — output above. They do run in the nightly `kokoro-coreml` shard.
- No `README.md` change, so the nine translations are untouched.

## Compatibility

Purely additive — no existing signature, resource, or behaviour changes. Callers that never call `addPronunciations` are unaffected.
