### PR TITLE
Improve configurable streaming wake-word decoding

### DIFF
--- a/Sources/AudioCLILib/WakeCommand.swift
+++ b/Sources/AudioCLILib/WakeCommand.swift
@@ -33,6 +33,18 @@ public struct WakeCommand: ParsableCommand {
     @Flag(name: .long, help: "Output as JSON")
     public var json: Bool = false
 
+    @Option(name: .long, help: "Number of active transducer hypotheses")
+    public var beam: Int = 4
+
+    @Option(name: .long, help: "Blank frames required after a matched keyword")
+    public var trailingBlanks: Int?
+
+    @Option(name: .long, help: "Seconds without a keyword emission before resetting search")
+    public var autoResetSeconds: Double?
+
+    @Option(name: .long, help: "Penalty subtracted from the blank-token logit")
+    public var blankPenalty: Float = 0
+
     public init() {}
 
     public func run() throws {
@@ -57,7 +69,17 @@ public struct WakeCommand: ParsableCommand {
 
             print("Detecting keywords for: \(specs.map { $0.phrase }.joined(separator: ", "))")
             let start = Date()
-            let detections = try detector.detect(audio: audio, sampleRate: 16000)
+            let options = WakeWordDecodingOptions(
+                beam: beam,
+                numTrailingBlanks: trailingBlanks,
+                blankPenalty: blankPenalty,
+                autoResetSeconds: autoResetSeconds
+            )
+            let detections = try detector.detect(
+                audio: audio,
+                sampleRate: 16000,
+                options: options
+            )
             let elapsed = Date().timeIntervalSince(start)
 
             if json {
@@ -66,7 +88,9 @@ public struct WakeCommand: ParsableCommand {
                 print("No keywords detected.")
             } else {
                 for d in detections {
-                    let t = String(format: "%.2f", d.time(frameShiftSeconds: 0.04))
+                    let time = d.streamTime(frameShiftSeconds: 0.04)
+                        ?? d.time(frameShiftSeconds: 0.04)
+                    let t = String(format: "%.2f", time)
                     print("[\(t)s] \(d.phrase)")
                 }
                 print("\n\(detections.count) detection(s)")
@@ -129,11 +153,17 @@ public struct WakeCommand: ParsableCommand {
     private func printJSON(_ detections: [KeywordDetection]) {
         var items = [[String: Any]]()
         for d in detections {
+            let streamFrame = d.streamFrameIndex ?? d.frameIndex
+            let streamTime = d.streamTime(frameShiftSeconds: 0.04)
+                ?? d.time(frameShiftSeconds: 0.04)
             items.append([
                 "phrase": d.phrase,
-                "frame": d.frameIndex,
-                "time": Double(String(format: "%.3f", d.time(frameShiftSeconds: 0.04)))!,
-                "tokens": d.tokenIds
+                "frame": streamFrame,
+                "time": Double(String(format: "%.3f", streamTime))!,
+                "tokens": d.tokenIds,
+                "tokenFrames": d.streamTimestamps ?? d.timestamps,
+                "decoderFrame": d.frameIndex,
+                "decoderTokenFrames": d.timestamps
             ])
         }
         if let data = try? JSONSerialization.data(withJSONObject: items, options: .prettyPrinted),

--- a/Sources/SpeechWakeWord/Configuration.swift
+++ b/Sources/SpeechWakeWord/Configuration.swift
@@ -125,3 +125,43 @@ public struct KeywordSpec: Sendable, Equatable {
         self.tokens = tokens
     }
 }
+
+/// Runtime search controls for one wake-word audio stream.
+///
+/// Model-owned defaults remain authoritative when an optional value is nil.
+/// Applications can widen the beam or allow a longer in-progress phrase
+/// without rebuilding or reloading the CoreML models.
+public struct WakeWordDecodingOptions: Sendable, Equatable {
+    /// Supported beam-width range for the shipped 500-piece transducer.
+    ///
+    /// Larger values multiply decoder/joiner calls without providing a
+    /// practical wake-word search benefit and can make a streaming session
+    /// fall behind real time.
+    public static let supportedBeamRange = 1...32
+
+    /// Longest supported interval before an incomplete search is reset.
+    public static let maximumAutoResetSeconds: Double = 3_600
+
+    /// Number of active transducer hypotheses retained after each frame.
+    public let beam: Int
+    /// Blank frames required after a complete keyword before it is emitted.
+    /// `nil` uses the model bundle's tuned default.
+    public let numTrailingBlanks: Int?
+    /// Logit penalty subtracted from the blank token.
+    public let blankPenalty: Float
+    /// Reset an incomplete search after this much audio without a keyword emission.
+    /// `nil` uses the model bundle's tuned default.
+    public let autoResetSeconds: Double?
+
+    public init(
+        beam: Int = 4,
+        numTrailingBlanks: Int? = nil,
+        blankPenalty: Float = 0,
+        autoResetSeconds: Double? = nil
+    ) {
+        self.beam = beam
+        self.numTrailingBlanks = numTrailingBlanks
+        self.blankPenalty = blankPenalty
+        self.autoResetSeconds = autoResetSeconds
+    }
+}

--- a/Sources/SpeechWakeWord/SpeechWakeWord+Protocols.swift
+++ b/Sources/SpeechWakeWord/SpeechWakeWord+Protocols.swift
@@ -21,9 +21,12 @@ public final class WakeWordStreamingAdapter: WakeWordProvider {
     public let detector: WakeWordDetector
     private let session: WakeWordSession
 
-    public init(detector: WakeWordDetector) throws {
+    public init(
+        detector: WakeWordDetector,
+        options: WakeWordDecodingOptions = WakeWordDecodingOptions()
+    ) throws {
         self.detector = detector
-        self.session = try detector.createSession()
+        self.session = try detector.createSession(options: options)
     }
 
     public var inputSampleRate: Int { detector.config.feature.sampleRate }

--- a/Sources/SpeechWakeWord/SpeechWakeWord.swift
+++ b/Sources/SpeechWakeWord/SpeechWakeWord.swift
@@ -54,7 +54,9 @@ public final class WakeWordDetector {
     /// Create a new streaming detection session sharing this detector's models
     /// and context graph. Call ``WakeWordSession/reset()`` between unrelated
     /// audio streams.
-    public func createSession() throws -> WakeWordSession {
+    public func createSession(
+        options: WakeWordDecodingOptions = WakeWordDecodingOptions()
+    ) throws -> WakeWordSession {
         guard _isLoaded, let encoder, let decoder, let joiner else {
             throw AudioModelError.inferenceFailed(operation: "createSession", reason: "Model not loaded")
         }
@@ -64,20 +66,25 @@ public final class WakeWordDetector {
             decoder: decoder,
             joiner: joiner,
             fbank: fbank,
-            contextGraph: contextGraph
+            contextGraph: contextGraph,
+            options: options
         )
     }
 
     /// Batch-detect keyword occurrences in a full audio buffer.
     /// Convenience wrapper around ``createSession``. Resamples to 16 kHz if needed.
-    public func detect(audio: [Float], sampleRate: Int) throws -> [KeywordDetection] {
+    public func detect(
+        audio: [Float],
+        sampleRate: Int,
+        options: WakeWordDecodingOptions = WakeWordDecodingOptions()
+    ) throws -> [KeywordDetection] {
         let samples: [Float]
         if sampleRate != config.feature.sampleRate {
             samples = AudioFileLoader.resample(audio, from: sampleRate, to: config.feature.sampleRate)
         } else {
             samples = audio
         }
-        let session = try createSession()
+        let session = try createSession(options: options)
         var detections = try session.pushAudio(samples)
         detections.append(contentsOf: try session.finalize())
         return detections
@@ -103,6 +110,14 @@ public final class WakeWordDetector {
         guard let decoder = decoder, let joiner = joiner else {
             throw AudioModelError.inferenceFailed(operation: "makeKwsDecoder", reason: "Model not loaded")
         }
+        let resolvedOptions = try WakeWordDecodingOptions(
+            beam: beam,
+            numTrailingBlanks: numTrailingBlanks,
+            autoResetSeconds: autoResetSeconds
+        ).resolved(
+            defaultNumTrailingBlanks: config.kws.defaultNumTrailingBlanks,
+            defaultAutoResetSeconds: config.kws.autoResetSeconds
+        )
         let graph = ContextGraph(contextScore: contextScore, acThreshold: acThreshold)
         var ids: [[Int]] = []
         var phrases: [String] = []
@@ -138,11 +153,11 @@ public final class WakeWordDetector {
             blankId: config.decoder.blankId,
             unkId: nil,
             contextSize: ctxSize,
-            beam: beam,
-            numTrailingBlanks: numTrailingBlanks,
+            beam: resolvedOptions.beam,
+            numTrailingBlanks: resolvedOptions.numTrailingBlanks,
             blankPenalty: 0,
             frameShiftSeconds: 0.04,
-            autoResetSeconds: autoResetSeconds
+            autoResetSeconds: resolvedOptions.autoResetSeconds
         )
     }
 

--- a/Sources/SpeechWakeWord/StreamingKwsDecoder.swift
+++ b/Sources/SpeechWakeWord/StreamingKwsDecoder.swift
@@ -9,11 +9,44 @@ public struct KeywordDetection: Sendable, Equatable {
     /// Encoder frame indices the tokens were emitted at (40 ms / frame).
     public let timestamps: [Int]
     /// Encoder frame index at which the emission fired.
+    ///
+    /// This index is local to the decoder's current search epoch and can
+    /// restart after an automatic reset or a keyword emission. Use
+    /// ``streamFrameIndex`` for a position in a ``WakeWordSession`` stream.
     public let frameIndex: Int
+    /// Monotonic encoder-frame index in the enclosing ``WakeWordSession``.
+    ///
+    /// Direct ``StreamingKwsDecoder`` use has no session clock and leaves this
+    /// value nil.
+    public let streamFrameIndex: Int?
+    /// Session-relative encoder-frame indices for the matched BPE tokens.
+    /// Direct ``StreamingKwsDecoder`` use leaves this value nil.
+    public let streamTimestamps: [Int]?
 
-    /// Detection time in seconds, given a ``frameShiftSeconds``.
+    public init(
+        phrase: String,
+        tokenIds: [Int],
+        timestamps: [Int],
+        frameIndex: Int,
+        streamFrameIndex: Int? = nil,
+        streamTimestamps: [Int]? = nil
+    ) {
+        self.phrase = phrase
+        self.tokenIds = tokenIds
+        self.timestamps = timestamps
+        self.frameIndex = frameIndex
+        self.streamFrameIndex = streamFrameIndex
+        self.streamTimestamps = streamTimestamps
+    }
+
+    /// Decoder-local detection time in seconds, given a ``frameShiftSeconds``.
     public func time(frameShiftSeconds: Double) -> Double {
         Double(frameIndex) * frameShiftSeconds
+    }
+
+    /// Detection time relative to the start of the enclosing session.
+    public func streamTime(frameShiftSeconds: Double) -> Double? {
+        streamFrameIndex.map { Double($0) * frameShiftSeconds }
     }
 }
 
@@ -27,6 +60,18 @@ public struct KeywordDetection: Sendable, Equatable {
 public final class StreamingKwsDecoder {
     public typealias DecoderFn = ([Int]) -> [Float]
     public typealias JoinerFn = ([Float], [Float]) -> [Float]
+
+    /// One acoustic expansion considered for the next beam. ``insertionOrder``
+    /// freezes the old full-sort behavior for equal scores: candidates were
+    /// enumerated by hypothesis and then token, so an earlier candidate wins a
+    /// boundary tie deterministically.
+    struct Candidate: Equatable {
+        let totalLogProb: Double
+        let hypIndex: Int
+        let token: Int
+        let tokenProb: Double
+        let insertionOrder: Int
+    }
 
     public let contextGraph: ContextGraph
     public let blankId: Int
@@ -65,11 +110,20 @@ public final class StreamingKwsDecoder {
         self.blankId = blankId
         self.unkId = unkId ?? blankId
         self.contextSize = contextSize
-        self.beam = beam
+        // WakeWordDecodingOptions rejects out-of-range values before this
+        // lower-level decoder is built. Clamp direct construction as a final
+        // guard against pathological allocations or model-call counts.
+        self.beam = min(
+            max(beam, WakeWordDecodingOptions.supportedBeamRange.lowerBound),
+            WakeWordDecodingOptions.supportedBeamRange.upperBound
+        )
         self.numTrailingBlanks = numTrailingBlanks
         self.blankPenalty = blankPenalty
         self.frameShiftSeconds = frameShiftSeconds
-        self.autoResetFrames = max(1, Int((autoResetSeconds / frameShiftSeconds).rounded()))
+        self.autoResetFrames = Self.safeAutoResetFrameCount(
+            seconds: autoResetSeconds,
+            frameShiftSeconds: frameShiftSeconds
+        )
         reset()
     }
 
@@ -112,15 +166,15 @@ public final class StreamingKwsDecoder {
     public func step(encoderFrame: [Float]) -> [KeywordDetection] {
         var emissions: [KeywordDetection] = []
 
-        // Expand beam across candidate tokens.
-        struct Candidate {
-            let totalLogProb: Double
-            let hypIndex: Int
-            let token: Int
-            let tokenProb: Double
-        }
-        var candidates: [Candidate] = []
-        candidates.reserveCapacity(beamList.count * 32)
+        // Expand the beam while retaining only the global top B candidates.
+        // The former implementation materialized beam*vocab candidates and
+        // fully sorted them even though only B were consumed. With the shipped
+        // vocabulary that meant sorting up to 8,000 values per encoder frame
+        // at beam 16. This bounded list has identical ranking semantics and
+        // stores at most B values.
+        var topCandidates: [Candidate] = []
+        topCandidates.reserveCapacity(beam)
+        var insertionOrder = 0
 
         for (i, hyp) in beamList.enumerated() {
             let decOut = decoderFor(hyp.ys)
@@ -130,22 +184,23 @@ public final class StreamingKwsDecoder {
             }
             let (logProbs, probs) = Self.logSoftmax(logits)
             for token in 0..<logProbs.count {
-                candidates.append(
+                Self.retainTopCandidate(
                     Candidate(
                         totalLogProb: hyp.logProb + Double(logProbs[token]),
                         hypIndex: i,
                         token: token,
-                        tokenProb: Double(probs[token])
-                    )
+                        tokenProb: Double(probs[token]),
+                        insertionOrder: insertionOrder
+                    ),
+                    in: &topCandidates,
+                    limit: beam
                 )
+                insertionOrder += 1
             }
         }
 
-        candidates.sort { $0.totalLogProb > $1.totalLogProb }
-        let topK = candidates.prefix(beam)
-
         var nextBeam: [String: Hypothesis] = [:]
-        for cand in topK {
+        for cand in topCandidates {
             var hyp = beamList[cand.hypIndex]
             hyp.numTailingBlanks += 1
 
@@ -235,6 +290,58 @@ public final class StreamingKwsDecoder {
 
     // MARK: - helpers
 
+    /// Total ordering used by the bounded selector. Acoustic score remains the
+    /// primary key. The secondary key only resolves exact ties and preserves
+    /// the candidate enumeration order used by the previous full sort.
+    static func candidateRanksBefore(_ lhs: Candidate, _ rhs: Candidate) -> Bool {
+        if lhs.totalLogProb != rhs.totalLogProb {
+            return lhs.totalLogProb > rhs.totalLogProb
+        }
+        return lhs.insertionOrder < rhs.insertionOrder
+    }
+
+    /// Insert one value into an already-ranked bounded list. The list never
+    /// grows beyond ``limit`` and therefore avoids allocating or sorting the
+    /// discarded vocabulary expansions.
+    static func retainTopCandidate(
+        _ candidate: Candidate,
+        in candidates: inout [Candidate],
+        limit: Int
+    ) {
+        guard limit > 0 else { return }
+        if candidates.count == limit,
+           let last = candidates.last,
+           !candidateRanksBefore(candidate, last) {
+            return
+        }
+
+        var lower = 0
+        var upper = candidates.count
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2
+            if candidateRanksBefore(candidate, candidates[middle]) {
+                upper = middle
+            } else {
+                lower = middle + 1
+            }
+        }
+        candidates.insert(candidate, at: lower)
+        if candidates.count > limit {
+            candidates.removeLast()
+        }
+    }
+
+    /// Testable convenience that exercises the same streaming retention path
+    /// as ``step(encoderFrame:)`` without requiring Core ML models.
+    static func boundedTopCandidates(_ input: [Candidate], limit: Int) -> [Candidate] {
+        var result: [Candidate] = []
+        result.reserveCapacity(max(0, limit))
+        for candidate in input {
+            retainTopCandidate(candidate, in: &result, limit: limit)
+        }
+        return result
+    }
+
     private func decoderFor(_ ys: [Int]) -> [Float] {
         let ctx = Array(ys.suffix(contextSize))
         if let cached = decCache[ctx] { return cached }
@@ -248,6 +355,25 @@ public final class StreamingKwsDecoder {
         if b == -Double.infinity { return a }
         let m = max(a, b)
         return m + log1p(exp(-abs(a - b)))
+    }
+
+    /// Convert a duration to frames without allowing a finite but enormous
+    /// Double to trap during Int conversion. Session-facing options are
+    /// rejected above the documented maximum; this saturation protects direct
+    /// construction of the lower-level decoder as well.
+    static func safeAutoResetFrameCount(
+        seconds: Double,
+        frameShiftSeconds: Double
+    ) -> Int {
+        guard seconds.isFinite, seconds > 0,
+              frameShiftSeconds.isFinite, frameShiftSeconds > 0 else {
+            return 1
+        }
+        let rounded = (seconds / frameShiftSeconds).rounded()
+        guard rounded.isFinite, rounded < Double(Int.max) else {
+            return Int.max
+        }
+        return max(1, Int(rounded))
     }
 
     static func logSoftmax(_ logits: [Float]) -> (log: [Float], prob: [Float]) {

--- a/Sources/SpeechWakeWord/StreamingSession.swift
+++ b/Sources/SpeechWakeWord/StreamingSession.swift
@@ -2,6 +2,92 @@ import CoreML
 import Foundation
 import AudioCommon
 
+struct ResolvedWakeWordDecodingOptions: Equatable {
+    let beam: Int
+    let numTrailingBlanks: Int
+    let blankPenalty: Float
+    let autoResetSeconds: Double
+}
+
+extension WakeWordDecodingOptions {
+    func resolved(
+        defaultNumTrailingBlanks: Int,
+        defaultAutoResetSeconds: Double
+    ) throws -> ResolvedWakeWordDecodingOptions {
+        guard Self.supportedBeamRange.contains(beam) else {
+            throw AudioModelError.invalidConfiguration(
+                model: "KWS-Zipformer",
+                reason: "beam must be in \(Self.supportedBeamRange)"
+            )
+        }
+
+        let effectiveTrailingBlanks = numTrailingBlanks ?? defaultNumTrailingBlanks
+        guard effectiveTrailingBlanks >= 0 else {
+            throw AudioModelError.invalidConfiguration(
+                model: "KWS-Zipformer",
+                reason: "numTrailingBlanks must not be negative"
+            )
+        }
+        guard blankPenalty.isFinite else {
+            throw AudioModelError.invalidConfiguration(
+                model: "KWS-Zipformer", reason: "blankPenalty must be finite"
+            )
+        }
+
+        let effectiveAutoResetSeconds = autoResetSeconds ?? defaultAutoResetSeconds
+        guard effectiveAutoResetSeconds.isFinite,
+              effectiveAutoResetSeconds > 0,
+              effectiveAutoResetSeconds <= Self.maximumAutoResetSeconds else {
+            throw AudioModelError.invalidConfiguration(
+                model: "KWS-Zipformer",
+                reason: "autoResetSeconds must be finite, positive, and at most "
+                    + "\(Self.maximumAutoResetSeconds)"
+            )
+        }
+
+        return ResolvedWakeWordDecodingOptions(
+            beam: beam,
+            numTrailingBlanks: effectiveTrailingBlanks,
+            blankPenalty: blankPenalty,
+            autoResetSeconds: effectiveAutoResetSeconds
+        )
+    }
+}
+
+/// Session-owned clock for decoder output frames. The transducer decoder resets
+/// its local frame counter after inactivity and emissions, while this clock
+/// advances until the enclosing WakeWordSession is explicitly reset.
+struct WakeWordStreamClock {
+    private(set) var nextFrameIndex = 0
+
+    mutating func stamp(_ detections: [KeywordDetection]) -> [KeywordDetection] {
+        let streamFrameIndex = nextFrameIndex
+        if nextFrameIndex < Int.max {
+            nextFrameIndex += 1
+        }
+
+        return detections.map { detection in
+            let epochOffset = streamFrameIndex - detection.frameIndex
+            let streamTimestamps = detection.timestamps.map { timestamp in
+                let (value, overflow) = epochOffset.addingReportingOverflow(timestamp)
+                return overflow ? Int.max : value
+            }
+            return KeywordDetection(
+                phrase: detection.phrase,
+                tokenIds: detection.tokenIds,
+                timestamps: detection.timestamps,
+                frameIndex: detection.frameIndex,
+                streamFrameIndex: streamFrameIndex,
+                streamTimestamps: streamTimestamps
+            )
+        }
+    }
+
+    mutating func reset() {
+        nextFrameIndex = 0
+    }
+}
+
 /// Stateful wrapper over encoder/decoder/joiner + the streaming KWS decoder.
 ///
 /// One ``WakeWordSession`` = one independent streaming audio source. Not
@@ -13,6 +99,7 @@ public final class WakeWordSession {
     private let joiner: MLModel
     private let fbankSession: KaldiFbank.StreamingSession
     private let kwsDecoder: StreamingKwsDecoder
+    private var streamClock = WakeWordStreamClock()
 
     // Per-frame mel features buffered for the encoder sliding window. Stores
     // only frames that have not yet been consumed by an encoder chunk.
@@ -28,8 +115,13 @@ public final class WakeWordSession {
         decoder: MLModel,
         joiner: MLModel,
         fbank: KaldiFbank,
-        contextGraph: ContextGraph
+        contextGraph: ContextGraph,
+        options: WakeWordDecodingOptions = WakeWordDecodingOptions()
     ) throws {
+        let resolvedOptions = try options.resolved(
+            defaultNumTrailingBlanks: config.kws.defaultNumTrailingBlanks,
+            defaultAutoResetSeconds: config.kws.autoResetSeconds
+        )
         self.config = config
         self.encoder = encoder
         self.decoder = decoder
@@ -69,11 +161,11 @@ public final class WakeWordSession {
             blankId: config.decoder.blankId,
             unkId: nil,
             contextSize: config.decoder.contextSize,
-            beam: 4,
-            numTrailingBlanks: config.kws.defaultNumTrailingBlanks,
-            blankPenalty: 0,
+            beam: resolvedOptions.beam,
+            numTrailingBlanks: resolvedOptions.numTrailingBlanks,
+            blankPenalty: resolvedOptions.blankPenalty,
             frameShiftSeconds: 0.04,
-            autoResetSeconds: config.kws.autoResetSeconds
+            autoResetSeconds: resolvedOptions.autoResetSeconds
         )
     }
 
@@ -89,6 +181,7 @@ public final class WakeWordSession {
                cachedEmbedLeftPad.count * MemoryLayout<Float>.stride)
         processedLens.dataPointer.assumingMemoryBound(to: Int32.self)[0] = 0
         kwsDecoder.reset()
+        streamClock.reset()
     }
 
     /// Push raw PCM and return any keyword detections that fired.
@@ -137,7 +230,11 @@ public final class WakeWordSession {
         while melBuffer.count >= totalIn {
             let window = Array(melBuffer.prefix(totalIn))
             let encoderFrames = try runEncoder(melWindow: window)
-            emissions.append(contentsOf: kwsDecoder.stepChunk(encoderFrames))
+            for frame in encoderFrames {
+                emissions.append(contentsOf: streamClock.stamp(
+                    kwsDecoder.step(encoderFrame: frame)
+                ))
+            }
             melBuffer.removeFirst(stride)
         }
         return emissions

--- a/Tests/SpeechWakeWordTests/SpeechWakeWordTests.swift
+++ b/Tests/SpeechWakeWordTests/SpeechWakeWordTests.swift
@@ -345,6 +345,124 @@ final class ContextGraphTests: XCTestCase {
 
 final class StreamingKwsDecoderTests: XCTestCase {
 
+    func testDecodingOptionsDefaultsPreserveModelOwnedValues() {
+        let options = WakeWordDecodingOptions()
+        XCTAssertEqual(options.beam, 4)
+        XCTAssertNil(options.numTrailingBlanks)
+        XCTAssertEqual(options.blankPenalty, 0)
+        XCTAssertNil(options.autoResetSeconds)
+    }
+
+    func testDecodingOptionsAcceptDocumentedBounds() throws {
+        for beam in [
+            WakeWordDecodingOptions.supportedBeamRange.lowerBound,
+            WakeWordDecodingOptions.supportedBeamRange.upperBound
+        ] {
+            let resolved = try WakeWordDecodingOptions(
+                beam: beam,
+                autoResetSeconds: WakeWordDecodingOptions.maximumAutoResetSeconds
+            ).resolved(defaultNumTrailingBlanks: 1, defaultAutoResetSeconds: 1.5)
+            XCTAssertEqual(resolved.beam, beam)
+            XCTAssertEqual(
+                resolved.autoResetSeconds,
+                WakeWordDecodingOptions.maximumAutoResetSeconds
+            )
+        }
+    }
+
+    func testDecodingOptionsRejectPathologicalBeamWidths() {
+        for beam in [-1, 0, 33, Int.max] {
+            XCTAssertThrowsError(
+                try WakeWordDecodingOptions(beam: beam).resolved(
+                    defaultNumTrailingBlanks: 1,
+                    defaultAutoResetSeconds: 1.5
+                ),
+                "beam \(beam) should be rejected before decoder allocation"
+            )
+        }
+    }
+
+    func testDecodingOptionsRejectUnsafeAutoResetDurations() {
+        let invalidDurations: [Double] = [
+            -1,
+            0,
+            .infinity,
+            .nan,
+            WakeWordDecodingOptions.maximumAutoResetSeconds.nextUp,
+            .greatestFiniteMagnitude
+        ]
+        for duration in invalidDurations {
+            XCTAssertThrowsError(
+                try WakeWordDecodingOptions(autoResetSeconds: duration).resolved(
+                    defaultNumTrailingBlanks: 1,
+                    defaultAutoResetSeconds: 1.5
+                ),
+                "auto-reset duration \(duration) should be rejected"
+            )
+        }
+
+        XCTAssertThrowsError(
+            try WakeWordDecodingOptions().resolved(
+                defaultNumTrailingBlanks: 1,
+                defaultAutoResetSeconds: .greatestFiniteMagnitude
+            ),
+            "invalid model-owned defaults must not bypass validation"
+        )
+    }
+
+    func testAutoResetFrameConversionCannotTrapOnHugeFiniteValues() {
+        XCTAssertEqual(
+            StreamingKwsDecoder.safeAutoResetFrameCount(
+                seconds: .greatestFiniteMagnitude,
+                frameShiftSeconds: 0.04
+            ),
+            Int.max
+        )
+        XCTAssertEqual(
+            StreamingKwsDecoder.safeAutoResetFrameCount(
+                seconds: 10,
+                frameShiftSeconds: 0.04
+            ),
+            250
+        )
+        XCTAssertEqual(
+            StreamingKwsDecoder.safeAutoResetFrameCount(
+                seconds: .nan,
+                frameShiftSeconds: 0.04
+            ),
+            1
+        )
+    }
+
+    func testDirectDecoderClampsUnsafeBeamWidth() {
+        let graph = ContextGraph(contextScore: 0.5)
+        graph.build(tokenIds: [[1]], phrases: ["WAKE"], boosts: [0], thresholds: [0])
+        let decoderFn: StreamingKwsDecoder.DecoderFn = { _ in [0] }
+        let joinerFn: StreamingKwsDecoder.JoinerFn = { _, _ in [0, 0] }
+
+        let tooWide = StreamingKwsDecoder(
+            decoderFn: decoderFn,
+            joinerFn: joinerFn,
+            contextGraph: graph,
+            beam: Int.max
+        )
+        let nonPositive = StreamingKwsDecoder(
+            decoderFn: decoderFn,
+            joinerFn: joinerFn,
+            contextGraph: graph,
+            beam: Int.min
+        )
+
+        XCTAssertEqual(
+            tooWide.beam,
+            WakeWordDecodingOptions.supportedBeamRange.upperBound
+        )
+        XCTAssertEqual(
+            nonPositive.beam,
+            WakeWordDecodingOptions.supportedBeamRange.lowerBound
+        )
+    }
+
     /// Tiny backend: blank-only logits. Drives the beam to blanks forever.
     private func blankOnlyBackend(vocab: Int = 4) -> (StreamingKwsDecoder.DecoderFn, StreamingKwsDecoder.JoinerFn) {
         let decFn: StreamingKwsDecoder.DecoderFn = { _ in [Float](repeating: 0, count: 8) }
@@ -370,6 +488,85 @@ final class StreamingKwsDecoderTests: XCTestCase {
     func testLogAddExpStableAtInfinity() {
         XCTAssertEqual(StreamingKwsDecoder.logAddExp(-.infinity, 3.0), 3.0)
         XCTAssertEqual(StreamingKwsDecoder.logAddExp(3.0, -.infinity), 3.0)
+    }
+
+    func testBoundedTopCandidatesMatchesFullSortAcrossBeamsAndLogits() {
+        let hypothesisScores: [Double] = [-4.25, -1.5, 0, 0.75, 0.75]
+        let logitSets: [[Float]] = [
+            [8, 3, 1, -2, -9, -20],
+            [0, 0, 0, 0, 0, 0],
+            [2, -1, 2, -1, 2, -1],
+            [-Float.infinity, -3, -3, -7, -7, -Float.infinity]
+        ]
+
+        var candidates: [StreamingKwsDecoder.Candidate] = []
+        var insertionOrder = 0
+        for (hypIndex, hypothesisScore) in hypothesisScores.enumerated() {
+            for logits in logitSets {
+                let (logProbs, probs) = StreamingKwsDecoder.logSoftmax(logits)
+                for token in logits.indices {
+                    candidates.append(
+                        StreamingKwsDecoder.Candidate(
+                            totalLogProb: hypothesisScore + Double(logProbs[token]),
+                            hypIndex: hypIndex,
+                            token: token,
+                            tokenProb: Double(probs[token]),
+                            insertionOrder: insertionOrder
+                        )
+                    )
+                    insertionOrder += 1
+                }
+            }
+        }
+
+        for beam in [1, 2, 4, 8, 16, 32, candidates.count, candidates.count + 5] {
+            let reference = Array(candidates.sorted {
+                StreamingKwsDecoder.candidateRanksBefore($0, $1)
+            }.prefix(beam))
+            let bounded = StreamingKwsDecoder.boundedTopCandidates(
+                candidates,
+                limit: beam
+            )
+            XCTAssertEqual(bounded, reference, "bounded selection diverged at beam \(beam)")
+        }
+    }
+
+    func testBoundedTopCandidatesPreservesEnumerationOrderAcrossScoreTies() {
+        let candidates = (0..<64).map { index in
+            StreamingKwsDecoder.Candidate(
+                totalLogProb: -2,
+                hypIndex: index / 8,
+                token: index % 8,
+                tokenProb: 0.125,
+                insertionOrder: index
+            )
+        }
+
+        for beam in [1, 2, 4, 8, 16, 32, 64] {
+            let bounded = StreamingKwsDecoder.boundedTopCandidates(
+                candidates,
+                limit: beam
+            )
+            XCTAssertEqual(
+                bounded.map(\.insertionOrder),
+                Array(0..<beam),
+                "equal-score candidates must retain the prior enumeration order"
+            )
+        }
+    }
+
+    func testBoundedTopCandidatesRejectsNonPositiveLimit() {
+        let candidate = StreamingKwsDecoder.Candidate(
+            totalLogProb: 0,
+            hypIndex: 0,
+            token: 0,
+            tokenProb: 1,
+            insertionOrder: 0
+        )
+        XCTAssertEqual(
+            StreamingKwsDecoder.boundedTopCandidates([candidate], limit: 0),
+            []
+        )
     }
 
     func testBlankOnlyProducesNoEmissions() {
@@ -453,6 +650,65 @@ final class StreamingKwsDecoderTests: XCTestCase {
         }
         // No crash + beam still populated (single initial hypothesis).
         XCTAssertFalse(decoder.beamList.isEmpty)
+    }
+
+    func testSessionStreamClockSurvivesDecoderAutoAndEmissionResets() {
+        let graph = ContextGraph(contextScore: 2, acThreshold: 0)
+        graph.build(
+            tokenIds: [[1]], phrases: ["WAKE"], boosts: [0], thresholds: [0]
+        )
+        let decoderFn: StreamingKwsDecoder.DecoderFn = { _ in
+            [Float](repeating: 0, count: 8)
+        }
+        var emitToken = false
+        let joinerFn: StreamingKwsDecoder.JoinerFn = { _, _ in
+            emitToken ? [-10, 10, -10] : [10, -10, -10]
+        }
+        let decoder = StreamingKwsDecoder(
+            decoderFn: decoderFn,
+            joinerFn: joinerFn,
+            contextGraph: graph,
+            blankId: 0,
+            contextSize: 2,
+            beam: 1,
+            numTrailingBlanks: 0,
+            frameShiftSeconds: 0.04,
+            autoResetSeconds: 0.08
+        )
+        var streamClock = WakeWordStreamClock()
+        var detections: [KeywordDetection] = []
+        var rawDetections: [KeywordDetection] = []
+
+        // The first two blank frames force an automatic decoder reset. Each
+        // token/blank pair then emits and resets the decoder again.
+        for shouldEmitToken in [false, false, true, false, true, false] {
+            emitToken = shouldEmitToken
+            let raw = decoder.step(encoderFrame: [Float](repeating: 0, count: 8))
+            rawDetections.append(contentsOf: raw)
+            detections.append(contentsOf: streamClock.stamp(raw))
+        }
+
+        XCTAssertEqual(rawDetections.count, 2)
+        XCTAssertTrue(rawDetections.allSatisfy { $0.streamFrameIndex == nil })
+        XCTAssertTrue(rawDetections.allSatisfy { $0.streamTimestamps == nil })
+        XCTAssertEqual(detections.map(\.frameIndex), [1, 2])
+        XCTAssertEqual(detections.compactMap(\.streamFrameIndex), [3, 5])
+        XCTAssertEqual(detections.compactMap(\.streamTimestamps), [[2], [4]])
+        XCTAssertEqual(detections[0].streamTime(frameShiftSeconds: 0.04), 0.12)
+        XCTAssertEqual(detections[1].streamTime(frameShiftSeconds: 0.04), 0.20)
+
+        // Only an explicit session reset restarts the absolute clock.
+        decoder.reset()
+        streamClock.reset()
+        var afterExplicitReset: [KeywordDetection] = []
+        for shouldEmitToken in [true, false] {
+            emitToken = shouldEmitToken
+            afterExplicitReset.append(contentsOf: streamClock.stamp(
+                decoder.step(encoderFrame: [Float](repeating: 0, count: 8))
+            ))
+        }
+        XCTAssertEqual(afterExplicitReset.first?.streamFrameIndex, 1)
+        XCTAssertEqual(afterExplicitReset.first?.streamTimestamps, [0])
     }
 }
 
@@ -539,6 +795,24 @@ final class E2ESpeechWakeWordTests: XCTestCase {
         XCTAssertFalse(detections.contains(where: { $0.phrase == "LOVELY CHILD" }))
     }
 
+    func testCustomSearchOptionsDetectLightUp() throws {
+        let d = try detector
+        let url = try XCTUnwrap(Bundle.module.url(
+            forResource: "kws_light_up", withExtension: "wav"
+        ))
+        let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16_000)
+        let detections = try d.detect(
+            audio: audio,
+            sampleRate: 16_000,
+            options: WakeWordDecodingOptions(
+                beam: 8,
+                numTrailingBlanks: 3,
+                autoResetSeconds: 10
+            )
+        )
+        XCTAssertTrue(detections.contains { $0.phrase == "LIGHT UP" })
+    }
+
     func testDetectsLovelyChildOrForEver() throws {
         // 1.wav contains both "LOVELY CHILD" and "FOR EVER". The Python
         // reference only asserts one phrase per clip — mirror that here,
@@ -558,18 +832,22 @@ final class E2ESpeechWakeWordTests: XCTestCase {
         let url = try XCTUnwrap(Bundle.module.url(forResource: "kws_light_up", withExtension: "wav"))
         let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
         let session = try d.createSession()
-        var streamed: [String] = []
+        var streamed: [KeywordDetection] = []
         let chunkSize = 16000 / 4
         var offset = 0
         while offset < audio.count {
             let end = min(offset + chunkSize, audio.count)
             let dets = try session.pushAudio(Array(audio[offset..<end]))
-            streamed.append(contentsOf: dets.map { $0.phrase })
+            streamed.append(contentsOf: dets)
             offset = end
         }
-        streamed.append(contentsOf: try session.finalize().map { $0.phrase })
-        XCTAssertTrue(streamed.contains("LIGHT UP"),
-                      "streaming missed 'LIGHT UP' — saw \(streamed)")
+        streamed.append(contentsOf: try session.finalize())
+        XCTAssertTrue(streamed.contains { $0.phrase == "LIGHT UP" },
+                      "streaming missed 'LIGHT UP' — saw \(streamed.map(\.phrase))")
+        XCTAssertTrue(streamed.allSatisfy { $0.streamFrameIndex != nil })
+        XCTAssertTrue(streamed.allSatisfy {
+            $0.streamTimestamps?.count == $0.timestamps.count
+        })
     }
 
     func testStreamingRealTimeFactor() throws {

--- a/docs/inference/wake-word.md
+++ b/docs/inference/wake-word.md
@@ -24,7 +24,7 @@ let detector = try await WakeWordDetector.fromPretrained(
 let session = try detector.createSession()
 for chunk in audioStream {                         // Float32 @ 16 kHz
     for detection in try session.pushAudio(chunk) {
-        print("[\(detection.time(frameShiftSeconds: 0.04))s] \(detection.phrase)")
+        print("[\(detection.streamTime(frameShiftSeconds: 0.04) ?? 0)s] \(detection.phrase)")
     }
 }
 // Flush whatever's buffered when the stream ends:
@@ -33,6 +33,23 @@ for detection in try session.finalize() { print(detection.phrase) }
 // Batch — one-shot detection over a full file.
 let detections = try detector.detect(audio: samples, sampleRate: 16000)
 ```
+
+Search controls can be tuned per stream without reloading the models:
+
+```swift
+let options = WakeWordDecodingOptions(
+    beam: 8,
+    numTrailingBlanks: 3,
+    autoResetSeconds: 10
+)
+let session = try detector.createSession(options: options)
+```
+
+`beam` must be within `WakeWordDecodingOptions.supportedBeamRange` (`1...32`).
+`autoResetSeconds` must be positive and no greater than
+`WakeWordDecodingOptions.maximumAutoResetSeconds` (one hour). Invalid values
+are rejected when the session is created rather than being allowed to allocate
+an impractical search or overflow the decoder's frame counter.
 
 `KeywordSpec` fields:
 
@@ -48,8 +65,15 @@ let detections = try detector.detect(audio: samples, sampleRate: 16000)
 
 - `phrase` — the matching `KeywordSpec.phrase`.
 - `tokenIds` / `timestamps` — BPE ids and their encoder-frame offsets inside
-  the emission.
-- `frameIndex` — encoder frame at which the emission fired (40 ms / frame).
+  the decoder's current search epoch.
+- `frameIndex` — decoder-local encoder frame at which the emission fired
+  (40 ms / frame). It restarts after decoder auto-reset and keyword emission.
+- `streamTimestamps` — optional session-relative frame indices for the matched
+  BPE tokens. The final value marks the keyword's acoustic boundary, before
+  the trailing blanks used to confirm it.
+- `streamFrameIndex` — optional monotonically increasing detection frame in a
+  `WakeWordSession`. It restarts only when `WakeWordSession.reset()` is called.
+  Direct `StreamingKwsDecoder` use leaves both stream-relative fields nil.
 
 ## CLI
 
@@ -62,6 +86,10 @@ speech wake recording.wav --keywords "hey soniqo:0.1:0.5" "cancel:0.2"
 
 # JSON output:
 speech wake recording.wav --keywords "hey soniqo" --json
+
+# Wider search for a longer or unusual phrase:
+speech wake recording.wav --keywords "hey soniqo" \
+  --beam 8 --trailing-blanks 3 --auto-reset-seconds 10
 
 # Keyword file (one entry per line, `#` for comments):
 speech wake recording.wav --keywords-file keywords.txt


### PR DESCRIPTION
## Summary

- expose validated per-session KWS beam, trailing-blank, blank-penalty, and auto-reset controls while preserving current defaults
- add monotonic session-relative detection and token timestamps across decoder emissions and automatic resets
- replace full beam-by-vocabulary sorting with an equivalent bounded top-beam selector
- expose the controls and absolute stream timing through the wake CLI and document the public API

## Why

Consumers need wider search for difficult keyword fragments without losing the low-latency default path. Decoder-local frame indices reset during a stream, so they cannot safely identify an acoustic boundary in a rolling input buffer.

## Validation

- make build
- swift test --no-parallel --filter SpeechWakeWordTests --disable-sandbox
- 47 KWS tests passed, including real-model streaming and custom-option coverage
- measured KWS RTF: 0.050 on the local regression run