### PR TITLE
Fix wake-word reset after Core ML prediction

### DIFF
--- a/Sources/SpeechWakeWord/StreamingSession.swift
+++ b/Sources/SpeechWakeWord/StreamingSession.swift
@@ -173,13 +173,27 @@ public final class WakeWordSession {
     public func reset() throws {
         fbankSession.reset()
         melBuffer.removeAll(keepingCapacity: true)
-        for name in layerStates.keys {
-            let array = layerStates[name]!
+        var resetStates = [String: MLMultiArray]()
+        for (name, shape) in zip(config.encoder.layerStateNames, config.encoder.layerStateShapes) {
+            let array = try MLMultiArray(
+                shape: shape.map { NSNumber(value: $0) }, dataType: .float32
+            )
             memset(array.dataPointer, 0, array.count * MemoryLayout<Float>.stride)
+            resetStates[name] = array
         }
-        memset(cachedEmbedLeftPad.dataPointer, 0,
-               cachedEmbedLeftPad.count * MemoryLayout<Float>.stride)
-        processedLens.dataPointer.assumingMemoryBound(to: Int32.self)[0] = 0
+        layerStates = resetStates
+
+        let resetEmbedPad = try MLMultiArray(
+            shape: config.encoder.cachedEmbedLeftPadShape.map { NSNumber(value: $0) },
+            dataType: .float32
+        )
+        memset(resetEmbedPad.dataPointer, 0,
+               resetEmbedPad.count * MemoryLayout<Float>.stride)
+        cachedEmbedLeftPad = resetEmbedPad
+
+        let resetProcessedLens = try MLMultiArray(shape: [1], dataType: .int32)
+        resetProcessedLens.dataPointer.assumingMemoryBound(to: Int32.self)[0] = 0
+        processedLens = resetProcessedLens
         kwsDecoder.reset()
         streamClock.reset()
     }

--- a/Tests/SpeechWakeWordTests/SpeechWakeWordTests.swift
+++ b/Tests/SpeechWakeWordTests/SpeechWakeWordTests.swift
@@ -850,6 +850,26 @@ final class E2ESpeechWakeWordTests: XCTestCase {
         })
     }
 
+    func testStreamingResetAfterEncoderPredictionRestartsFromWritableState() throws {
+        let d = try detector
+        let url = try XCTUnwrap(Bundle.module.url(
+            forResource: "kws_light_up", withExtension: "wav"
+        ))
+        let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16_000)
+        let session = try d.createSession()
+
+        // An encoder prediction replaces the initially writable state arrays
+        // with Core ML-owned outputs. Some backends expose those outputs as
+        // read-only memory, so reset must allocate new state rather than
+        // zeroing the prediction buffers in place.
+        _ = try session.pushAudio(audio)
+        try session.reset()
+        var detections = try session.pushAudio(audio)
+        detections.append(contentsOf: try session.finalize())
+
+        XCTAssertTrue(detections.contains { $0.phrase == "LIGHT UP" })
+    }
+
     func testStreamingRealTimeFactor() throws {
         // Drive ~4s of audio in 320 ms chunks — target is the export's
         // measured RTF of 0.04. Generous ceiling so the test is robust on


### PR DESCRIPTION
Allocates fresh writable recurrent-state tensors during WakeWordSession.reset() instead of mutating Core ML-owned prediction outputs, which can be read-only and crash with SIGBUS. Adds an end-to-end regression that runs inference, resets the session, and detects the keyword again.