### PR TITLE
feat(download): transfer models through a background URLSession

### DIFF
--- a/Sources/AudioCommon/HuggingFaceBackgroundTransfer.swift
+++ b/Sources/AudioCommon/HuggingFaceBackgroundTransfer.swift
@@ -1,0 +1,537 @@
+import Foundation
+import os
+
+// MARK: - Out-of-process transfer
+//
+// An in-process `URLSession` stops when the process does. On a platform that
+// suspends an application the moment it leaves the screen, a multi-hundred
+// megabyte model transfer therefore freezes wherever it stood: the sockets go
+// down, the retry ladder's timers do not run, and nothing moves again until the
+// process is frontmost. A background session hands the transfer to the system
+// instead, which keeps it running while the process is suspended and relaunches
+// the process to deliver the result.
+//
+// It is opt-in, and stays that way, because it is not free. A background
+// session accepts only download tasks, so a range arrives as a file rather than
+// as bytes in memory; the system decides when the work runs; and the process
+// that receives a completion may be a fresh launch that never asked for the
+// download. Callers that are never suspended — a command-line tool, a desktop
+// process — gain nothing from any of that and keep the in-process path.
+
+/// Opt in to system-scheduled transfers that survive process suspension.
+public struct BackgroundTransferConfiguration: Sendable {
+    /// Identifies the session across launches.
+    ///
+    /// Reusing one identifier is what lets a new process adopt transfers an
+    /// earlier one started. Two live sessions may not share it.
+    public var sessionIdentifier: String
+
+    /// App-group container holding the session's own bookkeeping, required
+    /// when a transfer has to be visible to an extension as well.
+    public var sharedContainerIdentifier: String?
+
+    /// Let the system choose when to transfer, waiting for conditions it
+    /// prefers. Off by default: a model download blocks the feature that
+    /// needs it, so "later, when charging" is the wrong answer. The system
+    /// makes a session discretionary regardless when it is created while the
+    /// application is already in the background.
+    public var isDiscretionary: Bool
+
+    public var allowsCellularAccess: Bool
+
+    /// Total time the system allows one transfer before failing it.
+    ///
+    /// This stands in for the in-process stall guard, which cannot work here:
+    /// that clock keeps running while the process is suspended, so a transfer
+    /// the system was performing correctly the whole time would look stalled
+    /// the moment the process came back. The system owns the transfer, so the
+    /// system owns its deadline. Generous by default, because a large bundle
+    /// on a slow link legitimately takes hours and cancelling one that is
+    /// progressing throws away everything it has not yet committed.
+    public var resourceTimeout: TimeInterval
+
+    public init(
+        sessionIdentifier: String,
+        sharedContainerIdentifier: String? = nil,
+        isDiscretionary: Bool = false,
+        allowsCellularAccess: Bool = true,
+        resourceTimeout: TimeInterval = 24 * 60 * 60
+    ) {
+        self.sessionIdentifier = sessionIdentifier
+        self.sharedContainerIdentifier = sharedContainerIdentifier
+        self.isDiscretionary = isDiscretionary
+        self.allowsCellularAccess = allowsCellularAccess
+        self.resourceTimeout = resourceTimeout
+    }
+}
+
+/// What one background task is fetching, carried in its `taskDescription`.
+///
+/// The description is the only state that survives process death alongside the
+/// task itself, so it has to say everything needed to file the bytes: a
+/// relaunched process is handed tasks it has no memory of starting.
+struct BackgroundTransferItem: Codable, Sendable, Equatable {
+    /// `modelId/path`, for diagnostics only.
+    let label: String
+    /// Staging file for a chunk, final path for a whole file.
+    let destination: String
+    /// Chunk bookkeeping. Absent for a whole-file transfer.
+    let sidecar: String?
+    let expectedSize: Int64
+    let chunkCount: Int
+    /// Absent for a whole-file transfer.
+    let chunkIndex: Int?
+    let rangeStart: Int64?
+    let rangeEnd: Int64?
+
+    /// Bytes this task is expected to deliver.
+    var length: Int64 {
+        guard let rangeStart, let rangeEnd else { return expectedSize }
+        return rangeEnd - rangeStart + 1
+    }
+
+    /// Transfers are grouped by what they are assembling, so a completion can
+    /// find the writer and the waiting caller without a task identifier —
+    /// which is not stable across launches.
+    var groupKey: String { destination }
+
+    /// Position inside its group. A whole file is a group of one.
+    var slot: Int { chunkIndex ?? 0 }
+
+    func encoded() -> String? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func decoded(from description: String?) -> BackgroundTransferItem? {
+        guard let description, let data = description.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(BackgroundTransferItem.self, from: data)
+    }
+}
+
+/// Runs transfers on a background `URLSession` and files the results.
+///
+/// One coordinator per session identifier, kept for the life of the process:
+/// the session must not be recreated while it exists, and its delegate has to
+/// be there whenever the system decides to deliver something.
+final class BackgroundTransferCoordinator: NSObject, @unchecked Sendable {
+
+    private struct Group {
+        let label: String
+        var outstanding: Set<Int>
+        var continuation: CheckedContinuation<Void, Error>?
+        var finished = false
+    }
+
+    private static let registryLock = NSLock()
+    nonisolated(unsafe) private static var registry: [String: BackgroundTransferCoordinator] = [:]
+
+    static func coordinator(
+        for configuration: BackgroundTransferConfiguration
+    ) -> BackgroundTransferCoordinator {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        if let existing = registry[configuration.sessionIdentifier] {
+            return existing
+        }
+        let created = BackgroundTransferCoordinator(configuration: configuration)
+        registry[configuration.sessionIdentifier] = created
+        return created
+    }
+
+    /// The coordinator owning `identifier`, if this process has built one.
+    static func existingCoordinator(for identifier: String) -> BackgroundTransferCoordinator? {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        return registry[identifier]
+    }
+
+    private let configuration: BackgroundTransferConfiguration
+    private let lock = NSLock()
+    private var groups: [String: Group] = [:]
+    private var writers: [String: ChunkedFileWriter] = [:]
+    private var progress: [String: RangedDownloadProgress] = [:]
+    private var sessionFinishedHandlers: [@Sendable () -> Void] = []
+
+    /// Built in `init` rather than lazily, and assigned exactly once before
+    /// the coordinator is published: two sessions may not share one
+    /// identifier, and a `lazy var` reached from two threads builds two.
+    private var session: URLSession!
+
+    private init(configuration: BackgroundTransferConfiguration) {
+        self.configuration = configuration
+        super.init()
+        let sessionConfiguration = URLSessionConfiguration.background(
+            withIdentifier: configuration.sessionIdentifier)
+        sessionConfiguration.sharedContainerIdentifier = configuration.sharedContainerIdentifier
+        sessionConfiguration.isDiscretionary = configuration.isDiscretionary
+        sessionConfiguration.allowsCellularAccess = configuration.allowsCellularAccess
+        sessionConfiguration.timeoutIntervalForResource = configuration.resourceTimeout
+        sessionConfiguration.httpMaximumConnectionsPerHost = max(
+            HuggingFaceDownloader.downloadRangeConcurrency, 1)
+        sessionConfiguration.sessionSendsLaunchEvents = true
+        session = URLSession(
+            configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+    }
+
+    /// Hand back the completion handler the system supplies when it relaunches
+    /// the process to deliver finished transfers.
+    func addSessionFinishedHandler(_ handler: @escaping @Sendable () -> Void) {
+        lock.lock()
+        sessionFinishedHandlers.append(handler)
+        lock.unlock()
+    }
+
+    // MARK: - Transfers
+
+    /// Fetch `chunks` of one file, resuming whatever a previous process left
+    /// running or already wrote.
+    func download(
+        chunks: [DownloadChunk],
+        from url: URL,
+        label: String,
+        writer: ChunkedFileWriter,
+        staging: URL,
+        sidecar: URL,
+        expectedSize: Int64,
+        chunkCount: Int,
+        progress: RangedDownloadProgress
+    ) async throws {
+        guard !chunks.isEmpty else { return }
+        let key = staging.path
+        let inFlight = await slotsInFlight(forGroup: key)
+        register(writer: writer, progress: progress, forGroup: key)
+
+        let toStart = chunks.filter { !inFlight.contains($0.index) }
+        let items = toStart.map { chunk in
+            BackgroundTransferItem(
+                label: label,
+                destination: staging.path,
+                sidecar: sidecar.path,
+                expectedSize: expectedSize,
+                chunkCount: chunkCount,
+                chunkIndex: chunk.index,
+                rangeStart: chunk.start,
+                rangeEnd: chunk.end)
+        }
+
+        try await run(
+            group: key,
+            label: label,
+            outstanding: Set(chunks.map(\.index)),
+            starting: items,
+            from: url)
+    }
+
+    /// Fetch one whole file, small enough not to be worth ranging.
+    func download(
+        wholeFile file: RepoFile,
+        from url: URL,
+        label: String,
+        to destination: URL
+    ) async throws {
+        let key = destination.path
+        let inFlight = await slotsInFlight(forGroup: key)
+        let items: [BackgroundTransferItem] = inFlight.contains(0)
+            ? []
+            : [BackgroundTransferItem(
+                label: label,
+                destination: destination.path,
+                sidecar: nil,
+                expectedSize: file.size,
+                chunkCount: 1,
+                chunkIndex: nil,
+                rangeStart: nil,
+                rangeEnd: nil)]
+
+        try await run(
+            group: key,
+            label: label,
+            outstanding: [0],
+            starting: items,
+            from: url)
+    }
+
+    private func register(
+        writer: ChunkedFileWriter,
+        progress: RangedDownloadProgress,
+        forGroup key: String
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        writers[key] = writer
+        self.progress[key] = progress
+    }
+
+    private func run(
+        group key: String,
+        label: String,
+        outstanding: Set<Int>,
+        starting items: [BackgroundTransferItem],
+        from url: URL
+    ) async throws {
+        let tasks = items.compactMap { item -> URLSessionDownloadTask? in
+            var request = HuggingFaceDownloader.makeHubRequest(url: url)
+            if let start = item.rangeStart, let end = item.rangeEnd {
+                request.setValue("bytes=\(start)-\(end)", forHTTPHeaderField: "Range")
+            }
+            guard let description = item.encoded() else { return nil }
+            let task = session.downloadTask(with: request)
+            task.taskDescription = description
+            return task
+        }
+        guard tasks.count == items.count else {
+            throw DownloadError.failedToDownload("\(label): could not describe a background transfer")
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                // Cancellation can arrive before the continuation exists, and
+                // the handler below would then have nothing to resume.
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                lock.lock()
+                if var existing = groups[key] {
+                    // Another caller in this process is already waiting on the
+                    // same file. Two waiters need two continuations; the older
+                    // one loses rather than being left unresumed.
+                    existing.continuation?.resume(throwing: CancellationError())
+                    existing.continuation = continuation
+                    existing.outstanding = outstanding
+                    existing.finished = false
+                    groups[key] = existing
+                } else {
+                    groups[key] = Group(
+                        label: label,
+                        outstanding: outstanding,
+                        continuation: continuation)
+                }
+                lock.unlock()
+                tasks.forEach { $0.resume() }
+            }
+        } onCancel: {
+            cancelTasks(inGroup: key)
+            finish(group: key, with: CancellationError())
+        }
+    }
+
+    private func slotsInFlight(forGroup key: String) async -> Set<Int> {
+        let tasks = await session.allTasks
+        var slots: Set<Int> = []
+        for task in tasks {
+            guard task.state == .running || task.state == .suspended,
+                  let item = BackgroundTransferItem.decoded(from: task.taskDescription),
+                  item.groupKey == key
+            else { continue }
+            slots.insert(item.slot)
+        }
+        return slots
+    }
+
+    private func cancelTasks(inGroup key: String) {
+        session.getAllTasks { tasks in
+            for task in tasks {
+                guard let item = BackgroundTransferItem.decoded(from: task.taskDescription),
+                      item.groupKey == key
+                else { continue }
+                task.cancel()
+            }
+        }
+    }
+
+    private func finish(group key: String, with error: Error?) {
+        lock.lock()
+        guard let group = groups[key], !group.finished else {
+            lock.unlock()
+            return
+        }
+        let continuation = group.continuation
+        groups.removeValue(forKey: key)
+        writers.removeValue(forKey: key)
+        progress.removeValue(forKey: key)
+        lock.unlock()
+
+        if let error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume()
+        }
+    }
+
+    /// Records a landed slot and answers whether the group is complete.
+    private func complete(slot: Int, inGroup key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var group = groups[key], !group.finished else { return false }
+        group.outstanding.remove(slot)
+        groups[key] = group
+        return group.outstanding.isEmpty
+    }
+}
+
+// MARK: - Delegate
+
+extension BackgroundTransferCoordinator: URLSessionDownloadDelegate {
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let item = BackgroundTransferItem.decoded(from: downloadTask.taskDescription) else {
+            AudioLog.download.error("background transfer finished without a description")
+            return
+        }
+        do {
+            try accept(location: location, for: item, response: downloadTask.response)
+        } catch {
+            AudioLog.download.error(
+                "\(item.label, privacy: .public): background transfer rejected: \(error.localizedDescription, privacy: .public)")
+            finish(group: item.groupKey, with: error)
+            cancelTasks(inGroup: item.groupKey)
+            return
+        }
+        reportLanded(item)
+        if complete(slot: item.slot, inGroup: item.groupKey) {
+            finish(group: item.groupKey, with: nil)
+        }
+    }
+
+    /// Progress is reported per landed range, the same unit the in-process
+    /// path uses. Byte-level callbacks would double-count: the system restarts
+    /// a task from zero after a redirect or a recoverable failure, and the
+    /// bytes it already reported are not taken back.
+    private func reportLanded(_ item: BackgroundTransferItem) {
+        guard item.chunkIndex != nil else { return }
+        lock.lock()
+        let state = progress[item.groupKey]
+        lock.unlock()
+        guard let state else { return }
+        let length = item.length
+        Task { await state.addCompletedBytes(length) }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        guard let error,
+              let item = BackgroundTransferItem.decoded(from: task.taskDescription)
+        else { return }
+        // A cancelled task is this coordinator tearing a failed group down;
+        // reporting it would replace the real reason with the tidy-up.
+        if (error as NSError).code == NSURLErrorCancelled { return }
+        AudioLog.download.error(
+            "\(item.label, privacy: .public): background transfer failed: \(error.localizedDescription, privacy: .public)")
+        finish(group: item.groupKey, with: error)
+        cancelTasks(inGroup: item.groupKey)
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        lock.lock()
+        let handlers = sessionFinishedHandlers
+        sessionFinishedHandlers.removeAll(keepingCapacity: false)
+        lock.unlock()
+        // The system expects to be answered on the main thread; the delegate
+        // queue is not it.
+        DispatchQueue.main.async { for handler in handlers { handler() } }
+    }
+
+    /// File the delivered bytes before returning: the system removes `location`
+    /// as soon as this call ends.
+    private func accept(
+        location: URL,
+        for item: BackgroundTransferItem,
+        response: URLResponse?
+    ) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw DownloadError.failedToDownload("\(item.label): missing HTTP response")
+        }
+        let expectedStatus = item.chunkIndex == nil ? 200 : 206
+        guard http.statusCode == expectedStatus else {
+            throw DownloadError.failedToDownload(
+                "\(item.label): expected HTTP \(expectedStatus), got \(http.statusCode)")
+        }
+        let delivered = HuggingFaceDownloader.localFileSize(location)
+        guard delivered == item.length else {
+            throw DownloadError.failedToDownload(
+                "\(item.label): got \(delivered) bytes, expected \(item.length)")
+        }
+
+        guard let chunkIndex = item.chunkIndex, let start = item.rangeStart else {
+            let destination = URL(fileURLWithPath: item.destination)
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: location, to: destination)
+            return
+        }
+
+        lock.lock()
+        let writer = writers[item.groupKey]
+        lock.unlock()
+
+        // A relaunched process is handed completions for transfers it never
+        // started and has no writer for. Opening one here would race the
+        // caller that is about to open its own, so the bytes are held beside
+        // the staging file and spliced by whoever asks for this file next.
+        guard let writer else {
+            try holdForLaterSplice(location: location, item: item, chunkIndex: chunkIndex)
+            return
+        }
+        try writer.write(Data(contentsOf: location), at: start, chunkIndex: chunkIndex)
+    }
+
+    private func holdForLaterSplice(
+        location: URL,
+        item: BackgroundTransferItem,
+        chunkIndex: Int
+    ) throws {
+        let held = BackgroundTransferCoordinator.heldChunkURL(
+            staging: URL(fileURLWithPath: item.destination), chunkIndex: chunkIndex)
+        try? FileManager.default.removeItem(at: held)
+        try FileManager.default.moveItem(at: location, to: held)
+    }
+
+    /// Where a chunk waits when it lands in a process that is not assembling
+    /// its file yet.
+    static func heldChunkURL(staging: URL, chunkIndex: Int) -> URL {
+        staging.appendingPathExtension("held-\(chunkIndex)")
+    }
+
+    /// Throw away ranges held for a staging file that no longer describes
+    /// them — a reset staging file, or one already assembled and moved.
+    static func discardHeldChunks(staging: URL, chunks: [DownloadChunk]) {
+        for chunk in chunks {
+            try? FileManager.default.removeItem(
+                at: heldChunkURL(staging: staging, chunkIndex: chunk.index))
+        }
+    }
+
+    /// Splice anything a previous launch left beside the staging file.
+    ///
+    /// Held chunks are as good as written — they were validated when they
+    /// arrived — so this runs before deciding what still has to be fetched.
+    static func spliceHeldChunks(
+        staging: URL,
+        chunks: [DownloadChunk],
+        writer: ChunkedFileWriter
+    ) {
+        let fileManager = FileManager.default
+        for chunk in chunks {
+            let held = heldChunkURL(staging: staging, chunkIndex: chunk.index)
+            guard fileManager.fileExists(atPath: held.path),
+                  HuggingFaceDownloader.localFileSize(held) == chunk.length,
+                  let data = try? Data(contentsOf: held)
+            else { continue }
+            do {
+                try writer.write(data, at: chunk.start, chunkIndex: chunk.index)
+                try? fileManager.removeItem(at: held)
+            } catch {
+                AudioLog.download.error(
+                    "could not splice held chunk \(chunk.index): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}

--- a/Sources/AudioCommon/HuggingFaceDownloader.swift
+++ b/Sources/AudioCommon/HuggingFaceDownloader.swift
@@ -388,7 +388,7 @@ public enum HuggingFaceDownloader {
 
         for attempt in 1...maxAttempts {
             do {
-                try await withDownloadStallGuard(modelId: modelId) { tick in
+                try await withDownloadStallGuardIfInProcess(modelId: modelId) { tick in
                     let files = try await resolve()
                     tick(0)
                     try await downloadManifestFiles(
@@ -444,6 +444,53 @@ public enum HuggingFaceDownloader {
         default:
             return false
         }
+    }
+
+    // MARK: - Background transfer
+
+    private static let backgroundTransferLock = NSLock()
+    nonisolated(unsafe) private static var storedBackgroundTransfer: BackgroundTransferConfiguration?
+
+    /// Transfer model files through a background `URLSession` that keeps
+    /// running while the process is suspended.
+    ///
+    /// `nil` — the default — keeps the in-process session every caller has
+    /// today. Set it once, before the first download, from a host that can be
+    /// suspended; see `BackgroundTransferConfiguration` for what it costs.
+    public static var backgroundTransfer: BackgroundTransferConfiguration? {
+        get {
+            backgroundTransferLock.lock()
+            defer { backgroundTransferLock.unlock() }
+            return storedBackgroundTransfer
+        }
+        set {
+            backgroundTransferLock.lock()
+            storedBackgroundTransfer = newValue
+            backgroundTransferLock.unlock()
+        }
+    }
+
+    /// Hand back the completion handler the system supplies when it relaunches
+    /// the process to deliver finished background transfers.
+    ///
+    /// The handler must be called, so an identifier this process knows nothing
+    /// about is answered immediately rather than dropped.
+    public static func handleBackgroundSessionEvents(
+        identifier: String,
+        completionHandler: @escaping @Sendable () -> Void
+    ) {
+        if let existing = BackgroundTransferCoordinator.existingCoordinator(for: identifier) {
+            existing.addSessionFinishedHandler(completionHandler)
+            return
+        }
+        guard let configuration = backgroundTransfer,
+              configuration.sessionIdentifier == identifier
+        else {
+            completionHandler()
+            return
+        }
+        BackgroundTransferCoordinator.coordinator(for: configuration)
+            .addSessionFinishedHandler(completionHandler)
     }
 
     // MARK: - Retry ladder
@@ -550,6 +597,25 @@ public enum HuggingFaceDownloader {
             lock.lock(); defer { lock.unlock() }
             return Date().timeIntervalSince(last)
         }
+    }
+
+    /// Apply the stall guard only when this process is the one transferring.
+    ///
+    /// The guard measures wall-clock time since the last reported byte, which
+    /// says nothing about a background session: its clock keeps running while
+    /// the process is suspended, so a transfer the system was performing
+    /// correctly the whole time would look wedged the moment the process came
+    /// back. A background transfer is bounded by the session's own resource
+    /// timeout instead, which the system enforces out of process.
+    static func withDownloadStallGuardIfInProcess(
+        modelId: String,
+        _ operation: @escaping (@escaping @Sendable (Double) -> Void) async throws -> Void
+    ) async throws {
+        guard backgroundTransfer == nil else {
+            try await operation { _ in }
+            return
+        }
+        try await withDownloadStallGuard(modelId: modelId, operation)
     }
 
     /// Run a download `operation` that reports progress, and abort it if

--- a/Sources/AudioCommon/HuggingFaceTransfer.swift
+++ b/Sources/AudioCommon/HuggingFaceTransfer.swift
@@ -124,6 +124,14 @@ extension HuggingFaceDownloader {
     /// interrupted transfer never leaves a short file at the real path.
     static func downloadWhole(_ file: RepoFile, modelId: String, to destination: URL) async throws {
         let url = try resolveURL(modelId: modelId, file: file.path)
+        if let background = HuggingFaceDownloader.backgroundTransfer {
+            try await BackgroundTransferCoordinator.coordinator(for: background).download(
+                wholeFile: file,
+                from: url,
+                label: "\(modelId)/\(file.path)",
+                to: destination)
+            return
+        }
         let request = makeHubRequest(url: url, timeout: 120)
         let (tempURL, response) = try await URLSession.shared.download(for: request)
         defer { try? FileManager.default.removeItem(at: tempURL) }
@@ -168,7 +176,22 @@ extension HuggingFaceDownloader {
             sidecar: sidecar,
             totalSize: file.size,
             chunkCount: chunks.count)
-        let alreadyDone = await writer.completedChunkIndices()
+        if HuggingFaceDownloader.backgroundTransfer != nil {
+            if writer.resumedExistingFile {
+                // A background transfer can land while no process is assembling
+                // this file. Those ranges wait beside the staging file, and are
+                // spliced here before anything decides what is still owed.
+                BackgroundTransferCoordinator.spliceHeldChunks(
+                    staging: staging, chunks: chunks, writer: writer)
+            } else {
+                // The staging file was reset, so it describes a different
+                // export than whatever is held. Held ranges of a matching
+                // length would splice cleanly and corrupt the result.
+                BackgroundTransferCoordinator.discardHeldChunks(
+                    staging: staging, chunks: chunks)
+            }
+        }
+        let alreadyDone = writer.completedChunkIndices()
 
         let state = RangedDownloadProgress(
             completedBeforeFile: completedBeforeFile,
@@ -180,7 +203,25 @@ extension HuggingFaceDownloader {
         }
 
         let pending = chunks.filter { !alreadyDone.contains($0.index) }
-        if !pending.isEmpty {
+        if !pending.isEmpty, let background = HuggingFaceDownloader.backgroundTransfer {
+            let url = try resolveURL(modelId: modelId, file: file.path)
+            do {
+                try await BackgroundTransferCoordinator.coordinator(for: background).download(
+                    chunks: pending,
+                    from: url,
+                    label: "\(modelId)/\(file.path)",
+                    writer: writer,
+                    staging: staging,
+                    sidecar: sidecar,
+                    expectedSize: file.size,
+                    chunkCount: chunks.count,
+                    progress: state)
+            } catch {
+                // Keep the staging file and sidecar: they are the resume point.
+                writer.close()
+                throw error
+            }
+        } else if !pending.isEmpty {
             let url = try resolveURL(modelId: modelId, file: file.path)
             let concurrency = downloadRangeConcurrency
             let configuration = URLSessionConfiguration.default
@@ -221,16 +262,23 @@ extension HuggingFaceDownloader {
                 }
             } catch {
                 // Keep the staging file and sidecar: they are the resume point.
-                await writer.close()
+                writer.close()
                 throw error
             }
         }
 
-        await writer.close()
+        writer.close()
 
         try? FileManager.default.removeItem(at: destination)
         try FileManager.default.moveItem(at: staging, to: destination)
         try? FileManager.default.removeItem(at: sidecar)
+        if HuggingFaceDownloader.backgroundTransfer != nil {
+            // A range delivered after the file was already assembled has
+            // nothing left to splice into, and would otherwise keep the
+            // staging directory alive forever.
+            BackgroundTransferCoordinator.discardHeldChunks(
+                staging: staging, chunks: chunks)
+        }
     }
 
     static func downloadRangeChunk(
@@ -258,7 +306,7 @@ extension HuggingFaceDownloader {
             throw DownloadError.failedToDownload(
                 "\(label) part \(chunk.index): got \(data.count) bytes, expected \(chunk.length)")
         }
-        try await writer.write(data, at: chunk.start, chunkIndex: chunk.index)
+        try writer.write(data, at: chunk.start, chunkIndex: chunk.index)
         await state.addCompletedBytes(chunk.length)
     }
 
@@ -381,7 +429,22 @@ struct DownloadChunk: Sendable {
 
 /// Serializes positional writes into the staging file and records which chunks
 /// have landed, so an interrupted transfer resumes instead of restarting.
-actor ChunkedFileWriter {
+///
+/// A lock rather than an actor: the background session delivers a finished
+/// range inside a delegate callback and deletes the file it handed over as soon
+/// as that callback returns, so the splice has to happen there and then. An
+/// actor can only be reached by suspending, which is exactly what a delegate
+/// callback cannot do.
+final class ChunkedFileWriter: @unchecked Sendable {
+    /// Whether this writer picked up a staging file a previous attempt left,
+    /// rather than starting one.
+    ///
+    /// A reset means the manifest's size disagreed with what is on disk, so
+    /// everything recorded about the old file describes a different export.
+    /// Anything else holding bytes for it has to be discarded too.
+    let resumedExistingFile: Bool
+
+    private let lock = NSLock()
     private let handle: FileHandle
     private let sidecar: URL
     private let chunkCount: Int
@@ -395,6 +458,7 @@ actor ChunkedFileWriter {
         let fm = FileManager.default
         let resumable = fm.fileExists(atPath: destination.path)
             && HuggingFaceDownloader.localFileSize(destination) == totalSize
+        self.resumedExistingFile = resumable
         if resumable {
             self.completed = Self.readSidecar(sidecar, chunkCount: chunkCount)
         } else {
@@ -421,10 +485,14 @@ actor ChunkedFileWriter {
     }
 
     func completedChunkIndices() -> Set<Int> {
-        completed
+        lock.lock()
+        defer { lock.unlock() }
+        return completed
     }
 
     func write(_ data: Data, at offset: Int64, chunkIndex: Int) throws {
+        lock.lock()
+        defer { lock.unlock() }
         guard !closed else {
             throw DownloadError.failedToDownload("write after close on chunk \(chunkIndex)")
         }
@@ -435,6 +503,8 @@ actor ChunkedFileWriter {
     }
 
     func close() {
+        lock.lock()
+        defer { lock.unlock() }
         guard !closed else { return }
         closed = true
         try? handle.synchronize()

--- a/Tests/AudioCommonTests/BackgroundTransferTests.swift
+++ b/Tests/AudioCommonTests/BackgroundTransferTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import AudioCommon
+
+/// A background transfer is delivered to whichever process the system chooses,
+/// which may be a fresh launch with no memory of starting it. Everything needed
+/// to file the bytes therefore has to survive in the task's own description and
+/// on disk — that is what these cover.
+final class BackgroundTransferItemTests: XCTestCase {
+
+    private func chunkItem(index: Int = 3) -> BackgroundTransferItem {
+        BackgroundTransferItem(
+            label: "org/model/weights.safetensors",
+            destination: "/tmp/cache/.incomplete/weights-abc",
+            sidecar: "/tmp/cache/.incomplete/weights-abc.chunks",
+            expectedSize: 33_554_432,
+            chunkCount: 4,
+            chunkIndex: index,
+            rangeStart: Int64(index) * 8_388_608,
+            rangeEnd: Int64(index + 1) * 8_388_608 - 1)
+    }
+
+    private var wholeItem: BackgroundTransferItem {
+        BackgroundTransferItem(
+            label: "org/model/config.json",
+            destination: "/tmp/cache/config.json",
+            sidecar: nil,
+            expectedSize: 1_024,
+            chunkCount: 1,
+            chunkIndex: nil,
+            rangeStart: nil,
+            rangeEnd: nil)
+    }
+
+    func testAChunkSurvivesTheRoundTripThroughATaskDescription() throws {
+        let item = chunkItem()
+        let description = try XCTUnwrap(item.encoded())
+
+        XCTAssertEqual(BackgroundTransferItem.decoded(from: description), item)
+    }
+
+    func testAWholeFileSurvivesTheRoundTripThroughATaskDescription() throws {
+        let item = wholeItem
+        let description = try XCTUnwrap(item.encoded())
+
+        XCTAssertEqual(BackgroundTransferItem.decoded(from: description), item)
+    }
+
+    /// Tasks started by something other than this downloader carry descriptions
+    /// that mean nothing here, and must not be mistaken for ours.
+    func testAnUnreadableDescriptionDecodesToNothing() {
+        XCTAssertNil(BackgroundTransferItem.decoded(from: nil))
+        XCTAssertNil(BackgroundTransferItem.decoded(from: ""))
+        XCTAssertNil(BackgroundTransferItem.decoded(from: "some other task"))
+    }
+
+    func testAChunkReportsTheLengthItsRangeAsksFor() {
+        XCTAssertEqual(chunkItem().length, 8_388_608)
+    }
+
+    /// A whole file has no range, so the file's own size is what is owed.
+    func testAWholeFileReportsTheFileSize() {
+        XCTAssertEqual(wholeItem.length, 1_024)
+    }
+
+    /// Completions are matched to the caller by what they are assembling. A
+    /// task identifier cannot do it: those are not stable across launches.
+    func testChunksOfOneFileShareAGroupAndKeepDistinctSlots() {
+        XCTAssertEqual(chunkItem(index: 0).groupKey, chunkItem(index: 1).groupKey)
+        XCTAssertEqual(chunkItem(index: 0).slot, 0)
+        XCTAssertEqual(chunkItem(index: 1).slot, 1)
+        XCTAssertEqual(wholeItem.slot, 0, "a whole file is a group of one")
+    }
+}
+
+/// A range can land while no process is assembling its file — the system
+/// relaunches the app to hand it over, and the caller that wanted it is long
+/// gone. Those bytes wait on disk instead of being thrown away.
+final class HeldChunkSpliceTests: XCTestCase {
+
+    private func makeScratch() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("held-chunk-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    private func chunks() -> [DownloadChunk] {
+        [
+            DownloadChunk(index: 0, start: 0, end: 7),
+            DownloadChunk(index: 1, start: 8, end: 15),
+        ]
+    }
+
+    func testAHeldRangeIsSplicedAndThenRemoved() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        let sidecar = staging.appendingPathExtension("chunks")
+        let held = BackgroundTransferCoordinator.heldChunkURL(staging: staging, chunkIndex: 1)
+        let payload = Data(repeating: 0xBB, count: 8)
+        try payload.write(to: held)
+
+        let writer = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        BackgroundTransferCoordinator.spliceHeldChunks(
+            staging: staging, chunks: chunks(), writer: writer)
+        let done = writer.completedChunkIndices()
+        writer.close()
+
+        XCTAssertEqual(done, [1], "the held range counts as written")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: held.path))
+        let assembled = try Data(contentsOf: staging)
+        XCTAssertEqual(assembled.subdata(in: 8..<16), payload)
+    }
+
+    /// A held file of the wrong length describes a different export, and
+    /// splicing it would put the wrong bytes at a valid offset.
+    func testAHeldRangeOfTheWrongLengthIsIgnored() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        let sidecar = staging.appendingPathExtension("chunks")
+        let held = BackgroundTransferCoordinator.heldChunkURL(staging: staging, chunkIndex: 0)
+        try Data(repeating: 0xCC, count: 5).write(to: held)
+
+        let writer = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        BackgroundTransferCoordinator.spliceHeldChunks(
+            staging: staging, chunks: chunks(), writer: writer)
+        let done = writer.completedChunkIndices()
+        writer.close()
+
+        XCTAssertTrue(done.isEmpty)
+    }
+
+    func testSplicingWithNothingHeldChangesNothing() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        let sidecar = staging.appendingPathExtension("chunks")
+
+        let writer = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        BackgroundTransferCoordinator.spliceHeldChunks(
+            staging: staging, chunks: chunks(), writer: writer)
+        let done = writer.completedChunkIndices()
+        writer.close()
+
+        XCTAssertTrue(done.isEmpty)
+    }
+
+    /// The dangerous case. A re-exported file changes size, the staging file
+    /// resets, and its sidecar is cleared — but a held range from the previous
+    /// export is still on disk under the same name, and an interior range of a
+    /// fixed-size chunking has exactly the right length to splice cleanly. It
+    /// would be recorded as complete and corrupt the result.
+    func testHeldRangesAreDiscardedWhenTheStagingFileResets() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        let sidecar = staging.appendingPathExtension("chunks")
+
+        let previousExport = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        previousExport.close()
+        XCTAssertFalse(previousExport.resumedExistingFile)
+
+        let held = BackgroundTransferCoordinator.heldChunkURL(staging: staging, chunkIndex: 1)
+        try Data(repeating: 0xBB, count: 8).write(to: held)
+
+        // Same path, different size: a re-export.
+        let reExport = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 24, chunkCount: 3)
+        XCTAssertFalse(
+            reExport.resumedExistingFile,
+            "a size change is a different file, not a resume")
+
+        BackgroundTransferCoordinator.discardHeldChunks(staging: staging, chunks: chunks())
+        BackgroundTransferCoordinator.spliceHeldChunks(
+            staging: staging, chunks: chunks(), writer: reExport)
+        let done = reExport.completedChunkIndices()
+        reExport.close()
+
+        XCTAssertTrue(done.isEmpty, "a range from the previous export must not be spliced")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: held.path))
+    }
+
+    /// A staging file that survived at its manifest size is a resume, and its
+    /// held ranges are still describing it.
+    func testAStagingFileAtItsManifestSizeCountsAsAResume() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        let sidecar = staging.appendingPathExtension("chunks")
+
+        let first = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        try first.write(Data(repeating: 0xAA, count: 8), at: 0, chunkIndex: 0)
+        first.close()
+
+        let resumed = try ChunkedFileWriter(
+            destination: staging, sidecar: sidecar, totalSize: 16, chunkCount: 2)
+        defer { resumed.close() }
+
+        XCTAssertTrue(resumed.resumedExistingFile)
+        XCTAssertEqual(resumed.completedChunkIndices(), [0])
+    }
+
+    /// A range delivered after the file was assembled has nothing to splice
+    /// into, and would otherwise keep the staging directory alive forever.
+    func testDiscardingRemovesEveryHeldRangeForAFile() throws {
+        let scratch = try makeScratch()
+        let staging = scratch.appendingPathComponent("staged.bin")
+        for index in 0...1 {
+            try Data(repeating: 0xEE, count: 8).write(
+                to: BackgroundTransferCoordinator.heldChunkURL(
+                    staging: staging, chunkIndex: index))
+        }
+
+        BackgroundTransferCoordinator.discardHeldChunks(staging: staging, chunks: chunks())
+
+        for index in 0...1 {
+            let held = BackgroundTransferCoordinator.heldChunkURL(
+                staging: staging, chunkIndex: index)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: held.path))
+        }
+    }
+
+    /// Held ranges sit beside the staging file rather than inside the cache
+    /// tree, where a partial transfer could be mistaken for repo content.
+    func testHeldRangesAreNamedBesideTheStagingFile() {
+        let staging = URL(fileURLWithPath: "/tmp/cache/.incomplete/weights-abc")
+        let held = BackgroundTransferCoordinator.heldChunkURL(staging: staging, chunkIndex: 7)
+
+        XCTAssertEqual(held.deletingLastPathComponent(), staging.deletingLastPathComponent())
+        XCTAssertEqual(held.lastPathComponent, "weights-abc.held-7")
+    }
+}
+
+/// Out-of-process transfer is opt-in, so every caller that is never suspended
+/// keeps the in-process session it has today.
+final class BackgroundTransferOptInTests: XCTestCase {
+
+    func testTheInProcessSessionIsTheDefault() {
+        XCTAssertNil(HuggingFaceDownloader.backgroundTransfer)
+    }
+
+    func testTheConfigurationRoundTripsAndCanBeCleared() {
+        let previous = HuggingFaceDownloader.backgroundTransfer
+        defer { HuggingFaceDownloader.backgroundTransfer = previous }
+
+        HuggingFaceDownloader.backgroundTransfer = BackgroundTransferConfiguration(
+            sessionIdentifier: "test.session.\(UUID().uuidString)")
+        XCTAssertNotNil(HuggingFaceDownloader.backgroundTransfer)
+
+        HuggingFaceDownloader.backgroundTransfer = nil
+        XCTAssertNil(HuggingFaceDownloader.backgroundTransfer)
+    }
+
+    /// A transfer that a slow link genuinely needs hours for must not be
+    /// cancelled by a deadline meant for a stalled one.
+    func testTheDefaultResourceDeadlineIsGenerous() {
+        let configuration = BackgroundTransferConfiguration(sessionIdentifier: "test.session")
+
+        XCTAssertGreaterThanOrEqual(configuration.resourceTimeout, 6 * 60 * 60)
+        XCTAssertFalse(
+            configuration.isDiscretionary,
+            "a model download blocks the feature that needs it")
+    }
+
+    /// The system requires its completion handler to be called. An identifier
+    /// this process knows nothing about is answered rather than dropped.
+    func testAnUnknownSessionIdentifierStillAnswersTheSystem() {
+        let previous = HuggingFaceDownloader.backgroundTransfer
+        defer { HuggingFaceDownloader.backgroundTransfer = previous }
+        HuggingFaceDownloader.backgroundTransfer = nil
+
+        let answered = expectation(description: "system completion handler called")
+        HuggingFaceDownloader.handleBackgroundSessionEvents(
+            identifier: "not.a.session.this.process.owns"
+        ) {
+            answered.fulfill()
+        }
+
+        wait(for: [answered], timeout: 1)
+    }
+}

--- a/Tests/AudioCommonTests/E2EDownloadResolutionTests.swift
+++ b/Tests/AudioCommonTests/E2EDownloadResolutionTests.swift
@@ -153,8 +153,8 @@ final class E2EDownloadResolutionTests: XCTestCase {
         var head = HuggingFaceDownloader.makeHubRequest(url: url, timeout: 60)
         head.setValue("bytes=0-262143", forHTTPHeaderField: "Range")
         let (firstChunk, _) = try await URLSession.shared.data(for: head)
-        try await writer.write(firstChunk, at: 0, chunkIndex: 0)
-        await writer.close()
+        try writer.write(firstChunk, at: 0, chunkIndex: 0)
+        writer.close()
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: sidecar.path))
 

--- a/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
+++ b/Tests/AudioCommonTests/HuggingFaceDownloaderTests.swift
@@ -803,10 +803,10 @@ final class ChunkedFileWriterTests: XCTestCase {
 
         let writer = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 20, chunkCount: 3)
-        try await writer.write(c, at: 16, chunkIndex: 2)
-        try await writer.write(a, at: 0, chunkIndex: 0)
-        try await writer.write(b, at: 8, chunkIndex: 1)
-        await writer.close()
+        try writer.write(c, at: 16, chunkIndex: 2)
+        try writer.write(a, at: 0, chunkIndex: 0)
+        try writer.write(b, at: 8, chunkIndex: 1)
+        writer.close()
 
         XCTAssertEqual(try Data(contentsOf: target), a + b + c)
     }
@@ -821,14 +821,14 @@ final class ChunkedFileWriterTests: XCTestCase {
 
         let first = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 24, chunkCount: 3)
-        try await first.write(Data(repeating: 0x01, count: 8), at: 0, chunkIndex: 0)
-        try await first.write(Data(repeating: 0x03, count: 8), at: 16, chunkIndex: 2)
-        await first.close()
+        try first.write(Data(repeating: 0x01, count: 8), at: 0, chunkIndex: 0)
+        try first.write(Data(repeating: 0x03, count: 8), at: 16, chunkIndex: 2)
+        first.close()
 
         let resumed = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 24, chunkCount: 3)
-        let done = await resumed.completedChunkIndices()
-        await resumed.close()
+        let done = resumed.completedChunkIndices()
+        resumed.close()
 
         XCTAssertEqual(done, [0, 2], "chunk 1 is the only one still owed")
     }
@@ -844,14 +844,14 @@ final class ChunkedFileWriterTests: XCTestCase {
 
         let stale = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 24, chunkCount: 3)
-        try await stale.write(Data(repeating: 0x01, count: 8), at: 0, chunkIndex: 0)
-        await stale.close()
+        try stale.write(Data(repeating: 0x01, count: 8), at: 0, chunkIndex: 0)
+        stale.close()
 
         // Same staging path, different expected size — a re-export.
         let fresh = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 32, chunkCount: 4)
-        let done = await fresh.completedChunkIndices()
-        await fresh.close()
+        let done = fresh.completedChunkIndices()
+        fresh.close()
 
         XCTAssertTrue(done.isEmpty, "stale chunk records must not be trusted")
         XCTAssertEqual(HuggingFaceDownloader.localFileSize(target), 32)
@@ -869,8 +869,8 @@ final class ChunkedFileWriterTests: XCTestCase {
 
         let writer = try ChunkedFileWriter(
             destination: target, sidecar: sidecar, totalSize: 16, chunkCount: 2)
-        let done = await writer.completedChunkIndices()
-        await writer.close()
+        let done = writer.completedChunkIndices()
+        writer.close()
 
         XCTAssertEqual(done, [0])
     }

--- a/docs/inference/cache-and-offline.md
+++ b/docs/inference/cache-and-offline.md
@@ -85,6 +85,61 @@ once complete. The directory is removed when empty; anything left in it is a
 resume point for an interrupted transfer and is safe to delete manually if you
 want to force a clean re-download.
 
+### Transfers that outlive the process
+
+The transfers above run inside the process, which is the right answer wherever
+the process keeps running. On iOS it is not: the system suspends an application
+shortly after it leaves the screen, and an in-process transfer stops with it —
+the sockets go down, the retry ladder's timers do not run, and a
+several-hundred-megabyte model freezes at whatever percentage it had reached
+until the application is frontmost again.
+
+Hand the transfer to the system instead by setting a background session
+identifier once, before the first download:
+
+```swift
+HuggingFaceDownloader.backgroundTransfer = BackgroundTransferConfiguration(
+    sessionIdentifier: "com.example.app.models")
+```
+
+and forwarding the completion handler the system supplies when it relaunches
+the process to deliver finished transfers:
+
+```swift
+func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+) {
+    HuggingFaceDownloader.handleBackgroundSessionEvents(
+        identifier: identifier, completionHandler: completionHandler)
+}
+```
+
+Everything else is unchanged: the same ranged chunks, the same staging file and
+sidecar, the same resume point. What changes is who performs the transfer.
+
+It is opt-in, and `nil` — the default — keeps the in-process session, because
+a background session is not free:
+
+- Only download tasks are allowed, so a range arrives as a file rather than as
+  bytes in memory. That costs a splice per chunk and saves the 128 MB of
+  transient buffers the in-process path holds at the default settings.
+- The system decides when the work runs. `isDiscretionary` is off by default so
+  it starts promptly, but a session created while the application is already in
+  the background is discretionary whatever this says.
+- A completion may be delivered to a process that never asked for it. A range
+  that lands with nobody assembling its file waits beside the staging file and
+  is spliced by whoever asks for that file next, so those bytes are not lost.
+- The stall guard does not apply. Its clock keeps running while the process is
+  suspended, so a transfer the system was performing correctly the whole time
+  would look wedged the moment the process came back. `resourceTimeout` bounds
+  the transfer instead, enforced by the system out of process; it defaults to
+  24 hours, because a large bundle on a slow link legitimately takes hours.
+
+Resolution against the Hub tree API stays an ordinary request either way — it
+is small, and it is the one part that cannot be handed over.
+
 ### When the Hub is unreachable
 
 Resolution always goes to the network, so that a re-exported model is picked


### PR DESCRIPTION
## Why

An in-process `URLSession` stops when the process does. On iOS the system suspends an application shortly after it leaves the screen, so a transfer of several hundred megabytes freezes at whatever percentage it had reached — the sockets go down, and the stall guard and retry ladder are timers that do not run while suspended either. Nothing moves again until the application is frontmost.

## What

Opt in with a session identifier and the transfer becomes the system's work:

```swift
HuggingFaceDownloader.backgroundTransfer = BackgroundTransferConfiguration(
    sessionIdentifier: "com.example.app.models")
```

plus forwarding the relaunch handler:

```swift
func application(
    _ application: UIApplication,
    handleEventsForBackgroundURLSession identifier: String,
    completionHandler: @escaping () -> Void
) {
    HuggingFaceDownloader.handleBackgroundSessionEvents(
        identifier: identifier, completionHandler: completionHandler)
}
```

The ranged chunks, the staging file and its sidecar are unchanged. What changes is who performs the transfer. Each range becomes a download task carrying its whole descriptor in `taskDescription`, because a completion may be delivered to a launch with no memory of starting it. A range that lands with nobody assembling its file waits beside the staging file and is spliced by whoever asks for that file next, so those bytes survive rather than being discarded.

## Architecture fit

`downloadManifestFiles` keeps its shape; both transfer paths sit behind the same entry point and produce the same staging file. Repository resolution stays an ordinary request either way — it is small and is the one part that cannot be handed over.

`ChunkedFileWriter` becomes a lock-guarded class rather than an actor. That is required, not tidying: the system deletes the file it hands over as soon as the delegate callback returns, so the splice has to happen inside that callback, which cannot suspend to reach an actor.

The stall guard is skipped when background transfer is on. Its clock keeps running while the process is suspended, so a transfer the system was performing correctly the whole time would look wedged the moment the process came back. The session's own `timeoutIntervalForResource` bounds it instead, enforced out of process, defaulting to 24 hours because a large bundle on a slow link legitimately takes hours.

## Regression risk

`nil` is the default and keeps the in-process session every current caller uses, so the only change on that path is the writer's actor-to-class conversion. Everything else is behind the opt-in.

The failure this could have introduced, found in review and fixed here: held ranges are **discarded** rather than spliced when the staging file resets. A re-exported file changes size and clears its sidecar, but an interior range of a fixed-size chunking still has exactly the right length to splice cleanly and be recorded as complete — corruption rather than a clean failure. There is a test for it.

Also from that review: the session is built in `init` rather than lazily, because a `lazy var` reached from two threads builds two sessions on one identifier; progress is reported per landed range rather than from `didWriteData`, which double-counts when the system restarts a task after a redirect; the relaunch completion handler is called on the main thread; and held ranges are swept after a file is assembled so they cannot keep `.incomplete/` alive forever.

## Tests

`swift test --filter 'AudioCommonTests.(HuggingFace|Download|Chunk|Repo|Manifest|BackgroundTransfer|HeldChunk)'` — 79 tests, 0 failures, 17 new: descriptor round-trip across a relaunch, group and slot identity, held-range splice including the wrong-length and reset-staging rejects, the resume flag, opt-in defaults, and the unknown-session handler contract. Full `swift build` clean.

Not covered by unit tests, and worth saying plainly: a real background session end to end. That needs an application on a device, and iOS cancels background transfers when a user force-quits the app — backgrounded is covered, force-quit is not, by design of the platform.

## Recommendation

Merge and adopt from an iOS host behind the opt-in. Every other consumer is unaffected until it sets the configuration.