### PR TITLE
fix(qwen3-asr): read CoreML audio embeddings as Float16

### DIFF
--- a/Sources/MLXCommon/MetalBudget.swift
+++ b/Sources/MLXCommon/MetalBudget.swift
@@ -31,12 +31,41 @@ public enum MetalBudget {
         Memory.activeMemory
     }
 
+    /// Fraction of the recommended working set wired by default.
+    ///
+    /// macOS keeps 90%: there, wiring genuinely prevents paging under
+    /// memory pressure. iOS and the other embedded platforms pin nothing.
+    /// ``maxRecommendedWorkingSetSize`` describes the *device's* GPU budget,
+    /// but what terminates an app on those platforms is its own jetsam
+    /// limit, which is far smaller and treats wired pages as
+    /// non-reclaimable. Wiring 90% of the device working set there asks the
+    /// OS to hold memory it may need back in order to keep the app alive.
+    /// A caller that wants pinning anyway can still pass a fraction.
+    #if os(macOS)
+    public static let defaultPinFraction: Double = 0.9
+    #else
+    public static let defaultPinFraction: Double = 0.0
+    #endif
+
+    /// The wired limit implied by a working-set size and fraction, or `nil`
+    /// when no limit should be set at all.
+    ///
+    /// Pure, so the policy is testable on any platform rather than only on
+    /// the one running the tests.
+    public static func wiredLimit(workingSet: Int, fraction: Double) -> Int? {
+        guard fraction > 0, workingSet > 0 else { return nil }
+        return Int(Double(workingSet) * fraction)
+    }
+
     /// Pin GPU memory to prevent paging under pressure.
-    /// Uses 90% of recommended working set by default.
-    /// Only effective on macOS 15+ / iOS 18+.
+    /// Uses ``defaultPinFraction`` — 90% of the recommended working set on
+    /// macOS, nothing on iOS. Only effective on macOS 15+ / iOS 18+.
+    ///
+    /// Returns the previous wired limit, or 0 when no limit was applied.
     @discardableResult
-    public static func pinMemory(fraction: Double = 0.9) -> Int {
-        let limit = Int(Double(maxRecommendedWorkingSet) * fraction)
+    public static func pinMemory(fraction: Double = defaultPinFraction) -> Int {
+        guard let limit = wiredLimit(workingSet: maxRecommendedWorkingSet, fraction: fraction)
+        else { return 0 }
         var previous: size_t = 0
         mlx_set_wired_limit(&previous, size_t(limit))
         return Int(previous)

--- a/Sources/Qwen3ASR/CoreMLASRModel.swift
+++ b/Sources/Qwen3ASR/CoreMLASRModel.swift
@@ -97,7 +97,10 @@ public class CoreMLASRModel {
 
     /// Transcribe audio to text using full CoreML pipeline.
     ///
-    /// The entire inference runs on CoreML (Neural Engine + CPU) without MLX GPU.
+    /// The three model dispatches all run on CoreML (Neural Engine + CPU),
+    /// but this path is **not** MLX-free: mel extraction and the encoder
+    /// output both round-trip through MLXArray, which evaluates on Metal.
+    /// For background execution use `transcribeWithoutMLX()`.
     public func transcribe(
         audio: [Float],
         sampleRate: Int = 16000,
@@ -238,10 +241,12 @@ public class CoreMLASRModel {
     ///
     /// Uses `featureExtractor.processRaw()` (CPU via Accelerate) and
     /// `encoder.encode(melData:melBins:timeFrames:)` (CoreML) to produce
-    /// MLMultiArray embeddings, then decodes using `audioEmbeddingFromMultiArray()`.
+    /// MLMultiArray embeddings, then bulk-extracts them via
+    /// `audioEmbeddingsToFloatArray()` and prefills in batched chunks.
     ///
-    /// This method is safe for iOS background execution where Metal GPU eval
-    /// (triggered by MLXArray operations) would cause a crash.
+    /// This is the only path with no MLXArray operations anywhere, so it is
+    /// the one that is safe for iOS background execution — `transcribe()`
+    /// still round-trips through MLX for mel extraction and encoder output.
     ///
     /// - Note: Requires `processRaw()` on WhisperFeatureExtractor and
     ///   `encode(melData:melBins:timeFrames:)` on CoreMLASREncoder, both added by T2.
@@ -286,25 +291,33 @@ public class CoreMLASRModel {
         }
         suffixTokens.append(Int32(T.asrTextTokenId))
 
-        // 5. Prefill: process all prefix tokens
+        // 5. Prefill: prefix tokens (one batched ANE dispatch per chunk)
         var lastLogits: MLMultiArray?
+        lastLogits = try decoder.decoderPrefillTokens(prefixTokens)
 
-        for token in prefixTokens {
-            let embedding = try decoder.embed(tokenId: token)
-            lastLogits = try decoder.decoderStep(embedding: embedding)
+        // 6. Prefill: audio embeddings. Bulk-extract once — dtype- and
+        // stride-aware, no MLX — then feed the decoder in batched chunks,
+        // exactly as `transcribe()` does. The previous per-token loop cost
+        // one fixed-T ANE dispatch per audio token (~300 for a 24 s clip)
+        // and read the Float16 encoder output as Float32, which both
+        // corrupted the embeddings and ran off the end of the buffer past
+        // token 194.
+        let audioEmbedsFlat = try decoder.audioEmbeddingsToFloatArray(
+            audioEmbeds, count: numAudioTokens)
+        let chunk = decoder.prefillBatchSize
+        var consumed = 0
+        while consumed < numAudioTokens {
+            let n = min(chunk, numAudioTokens - consumed)
+            lastLogits = try decoder.decoderPrefill(
+                flatEmbeddings: audioEmbedsFlat,
+                offset: consumed,
+                realCount: n,
+            )
+            consumed += n
         }
 
-        // 6. Prefill: process audio embeddings (MLX-free path)
-        for i in 0..<numAudioTokens {
-            let audioEmbed = try decoder.audioEmbeddingFromMultiArray(audioEmbeds, at: i)
-            lastLogits = try decoder.decoderStep(embedding: audioEmbed)
-        }
-
-        // Prefill: process suffix tokens
-        for token in suffixTokens {
-            let embedding = try decoder.embed(tokenId: token)
-            lastLogits = try decoder.decoderStep(embedding: embedding)
-        }
+        // Prefill: suffix tokens
+        lastLogits = try decoder.decoderPrefillTokens(suffixTokens)
 
         // 7. Autoregressive generation (same EOS note as `transcribe()` —
         // see that path for the background).

--- a/Sources/Qwen3ASR/CoreMLEncoder.swift
+++ b/Sources/Qwen3ASR/CoreMLEncoder.swift
@@ -99,7 +99,7 @@ public class CoreMLASREncoder {
         let melTime = melFeatures.dim(1)
         let melData: [Float] = melFeatures.asArray(Float.self)
         let raw = try encodeRaw(melData: melData, melBins: melBins, realFrames: melTime)
-        return (multiArrayToMLXArray(raw.embeddings), raw.outputLength)
+        return (try multiArrayToMLXArray(raw.embeddings), raw.outputLength)
     }
 
     // MARK: - MLX-free encoding (for iOS background / pure CoreML path)
@@ -186,7 +186,11 @@ public class CoreMLASREncoder {
         return EncodedAudio(embeddings: embeddings, outputLength: outLen)
     }
 
-    private func multiArrayToMLXArray(_ array: MLMultiArray) -> MLXArray {
+    /// Throws rather than reinterpreting an unexpected dtype. Reading a
+    /// non-Float32 buffer through a `Float` pointer is precisely the defect
+    /// that shipped in the MLX-free path: it corrupts every value, and for
+    /// narrower dtypes it also runs off the end of the allocation.
+    private func multiArrayToMLXArray(_ array: MLMultiArray) throws -> MLXArray {
         let shape = array.shape.map { $0.intValue }
         let count = array.count
 
@@ -199,9 +203,16 @@ public class CoreMLASREncoder {
         case .float32:
             let src = array.dataPointer.assumingMemoryBound(to: Float.self)
             return MLXArray(Array(UnsafeBufferPointer(start: src, count: count)), shape)
+        case .double:
+            let src = array.dataPointer.assumingMemoryBound(to: Float64.self)
+            var floats = [Float](repeating: 0, count: count)
+            for i in 0..<count { floats[i] = Float(src[i]) }
+            return MLXArray(floats, shape)
         default:
-            let src = array.dataPointer.assumingMemoryBound(to: Float.self)
-            return MLXArray(Array(UnsafeBufferPointer(start: src, count: count)), shape)
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML encoder",
+                reason: "Unsupported audio_embeddings dtype (raw \(array.dataType.rawValue)) — "
+                    + "expected Float16, Float32 or Float64")
         }
     }
 }

--- a/Sources/Qwen3ASR/CoreMLEncoder.swift
+++ b/Sources/Qwen3ASR/CoreMLEncoder.swift
@@ -127,6 +127,19 @@ public class CoreMLASREncoder {
                              realFrames: melFeatures.timeFrames)
     }
 
+    /// Clamp a model-reported audio-token count to what the embeddings
+    /// tensor can actually supply.
+    ///
+    /// ``output_length`` is computed in-graph. A re-export whose length
+    /// formula outran its own output tensor would otherwise hand callers an
+    /// index range that reads past the buffer — the same class of fault as
+    /// reading the Float16 embeddings as Float32, arriving by a different
+    /// route. ``internal`` so it is unit-testable without the model.
+    static func clampOutputLength(_ reported: Int, embeddingShape shape: [Int]) -> Int {
+        let availableTokens = shape.count >= 2 ? shape[shape.count - 2] : 0
+        return min(max(0, reported), max(0, availableTokens))
+    }
+
     /// Shared core: zero-pads ``melData`` to the fixed ``paddedMelLength``,
     /// runs the two-input/two-output graph, and returns the model's reported
     /// ``output_length`` alongside the full padded embeddings.
@@ -167,13 +180,9 @@ public class CoreMLASREncoder {
             throw AudioModelError.inferenceFailed(
                 operation: "CoreML encoder", reason: "Missing output_length output (encoder may be an older export without the chunked-attention mask)")
         }
-        // Clamp the model-reported length to the embeddings tensor's own
-        // token extent. ``output_length`` is computed in-graph; a re-export
-        // whose length formula outran its output tensor would otherwise hand
-        // callers an index range that reads past the buffer.
-        let embedShape = embeddings.shape.map { $0.intValue }
-        let availableTokens = embedShape.count >= 2 ? embedShape[embedShape.count - 2] : 0
-        let outLen = min(max(0, Int(lengthOut[0].int32Value)), availableTokens)
+        let outLen = Self.clampOutputLength(
+            Int(lengthOut[0].int32Value),
+            embeddingShape: embeddings.shape.map { $0.intValue })
         return EncodedAudio(embeddings: embeddings, outputLength: outLen)
     }
 

--- a/Sources/Qwen3ASR/CoreMLEncoder.swift
+++ b/Sources/Qwen3ASR/CoreMLEncoder.swift
@@ -167,7 +167,13 @@ public class CoreMLASREncoder {
             throw AudioModelError.inferenceFailed(
                 operation: "CoreML encoder", reason: "Missing output_length output (encoder may be an older export without the chunked-attention mask)")
         }
-        let outLen = max(0, Int(lengthOut[0].int32Value))
+        // Clamp the model-reported length to the embeddings tensor's own
+        // token extent. ``output_length`` is computed in-graph; a re-export
+        // whose length formula outran its output tensor would otherwise hand
+        // callers an index range that reads past the buffer.
+        let embedShape = embeddings.shape.map { $0.intValue }
+        let availableTokens = embedShape.count >= 2 ? embedShape[embedShape.count - 2] : 0
+        let outLen = min(max(0, Int(lengthOut[0].int32Value)), availableTokens)
         return EncodedAudio(embeddings: embeddings, outputLength: outLen)
     }
 

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -252,8 +252,12 @@ public class CoreMLTextDecoder {
     /// (embedding lookup, part1 hidden) may come back as Float16 with
     /// padded strides on ANE; a raw ``assumingMemoryBound(to: Float)``
     /// copy would then read garbage.
-    private static func copyRow(from src: MLMultiArray, sourceRow: Int, hidden: Int,
-                                to dst: UnsafeMutablePointer<Float>, destSlot: Int) {
+    ///
+    /// Exposed ``internal`` (not ``private``) so
+    /// ``CoreMLEmbeddingExtractionTests`` can pin the dtype/stride
+    /// behaviour without instantiating the three CoreML models.
+    static func copyRow(from src: MLMultiArray, sourceRow: Int, hidden: Int,
+                        to dst: UnsafeMutablePointer<Float>, destSlot: Int) {
         let rowStride = src.strides.count >= 2 ? src.strides[src.strides.count - 2].intValue : hidden
         let lastStride = src.strides.last?.intValue ?? 1
         let base = sourceRow * rowStride
@@ -281,14 +285,11 @@ public class CoreMLTextDecoder {
     public func decoderPrefill(embeddings: MLMultiArray, realCount n: Int) throws -> MLMultiArray {
         precondition(n > 0 && n <= batchSize,
                      "realCount \(n) must be in 1...\(batchSize)")
+        try Self.validateEmbeddingSource(embeddings, hidden: hiddenSize, requiredRows: n)
         let bufs = try writeChunk(realEmbeddingsSource: { (slot, dstPtr) in
-            let srcPtr = embeddings.dataPointer.assumingMemoryBound(to: Float.self)
             for t in 0..<n {
-                let srcOff = t * self.hiddenSize
-                let dstOff = (slot + t) * self.hiddenSize
-                for j in 0..<self.hiddenSize {
-                    dstPtr[dstOff + j] = srcPtr[srcOff + j]
-                }
+                Self.copyRow(from: embeddings, sourceRow: t, hidden: self.hiddenSize,
+                             to: dstPtr, destSlot: slot + t)
             }
         }, realCount: n)
         return try runParts(embeds: bufs.embeds, positions: bufs.positions, mask: bufs.mask)
@@ -542,15 +543,96 @@ public class CoreMLTextDecoder {
 
     /// Extract audio embedding at index from MLMultiArray (no MLX dependency).
     public func audioEmbeddingFromMultiArray(_ embeddings: MLMultiArray, at index: Int) throws -> MLMultiArray {
-        let hidden = embeddings.shape[2].intValue
-        let result = try MLMultiArray(shape: [1, 1, hidden as NSNumber], dataType: .float32)
-        let srcPtr = embeddings.dataPointer.assumingMemoryBound(to: Float.self)
-        let dstPtr = result.dataPointer.assumingMemoryBound(to: Float.self)
-        let offset = index * hidden
-        for i in 0..<hidden {
-            dstPtr[i] = srcPtr[offset + i]
+        let shape = embeddings.shape.map { $0.intValue }
+        guard let hidden = shape.last, hidden > 0 else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Embeddings have no trailing dimension (shape \(shape))")
         }
+        return try Self.extractRow(from: embeddings, at: index, hidden: hidden)
+    }
+
+    /// Bulk-copy the first ``count`` embedding rows into one contiguous
+    /// Float32 buffer, ready for
+    /// ``decoderPrefill(flatEmbeddings:offset:realCount:)``.
+    ///
+    /// This is how the background-safe path gets encoder output into the
+    /// decoder: dtype- and stride-aware, MLX-free, and one call instead of
+    /// a fixed-T ANE dispatch per audio token.
+    public func audioEmbeddingsToFloatArray(_ embeddings: MLMultiArray, count: Int) throws -> [Float] {
+        try Self.extractRows(from: embeddings, count: count, hidden: hiddenSize)
+    }
+
+    // MARK: - Internal: embedding extraction
+
+    /// Copy row ``index`` into a fresh ``[1, 1, hidden]`` Float32 array.
+    ///
+    /// Reads through ``copyRow``, so a Float16 or strided encoder output is
+    /// converted rather than reinterpreted. The previous
+    /// ``assumingMemoryBound(to: Float.self)`` read walked the buffer at
+    /// twice the real element stride against the Float16 encoder output,
+    /// which both returned garbage and ran off the end of the allocation
+    /// past row 194 of 390 (~15 s of audio).
+    ///
+    /// ``internal`` so ``CoreMLEmbeddingExtractionTests`` can pin this
+    /// without instantiating the three CoreML models.
+    static func extractRow(from embeddings: MLMultiArray, at index: Int, hidden: Int) throws -> MLMultiArray {
+        guard index >= 0 else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Negative embedding index \(index)")
+        }
+        try validateEmbeddingSource(embeddings, hidden: hidden, requiredRows: index + 1)
+
+        let result = try MLMultiArray(shape: [1, 1, hidden as NSNumber], dataType: .float32)
+        let dstPtr = result.dataPointer.assumingMemoryBound(to: Float.self)
+        copyRow(from: embeddings, sourceRow: index, hidden: hidden, to: dstPtr, destSlot: 0)
         return result
+    }
+
+    /// Copy the first ``count`` rows into a contiguous row-major Float32 buffer.
+    static func extractRows(from embeddings: MLMultiArray, count: Int, hidden: Int) throws -> [Float] {
+        try validateEmbeddingSource(embeddings, hidden: hidden, requiredRows: count)
+        guard count > 0 else { return [] }
+
+        var out = [Float](repeating: 0, count: count * hidden)
+        out.withUnsafeMutableBufferPointer { buf in
+            guard let base = buf.baseAddress else { return }
+            for row in 0..<count {
+                copyRow(from: embeddings, sourceRow: row, hidden: hidden,
+                        to: base, destSlot: row)
+            }
+        }
+        return out
+    }
+
+    /// Reject an embeddings buffer that cannot supply ``requiredRows`` rows
+    /// of ``hidden`` values.
+    ///
+    /// Catches the two ways a CoreML output has silently gone out of bounds
+    /// on this path: a model reporting more real tokens than its own output
+    /// tensor holds, and a trailing dimension that disagrees with the
+    /// decoder's hidden size. The dtype/stride hazard is ``copyRow``'s job.
+    static func validateEmbeddingSource(
+        _ embeddings: MLMultiArray, hidden: Int, requiredRows: Int
+    ) throws {
+        let shape = embeddings.shape.map { $0.intValue }
+        guard let last = shape.last, last == hidden else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Embedding width mismatch: buffer shape \(shape) does not end in hidden size \(hidden)")
+        }
+        let rows = shape.count >= 2 ? shape[shape.count - 2] : 1
+        guard requiredRows >= 0 else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Negative row count \(requiredRows)")
+        }
+        guard requiredRows <= rows else {
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Requested \(requiredRows) embedding rows but buffer shape \(shape) holds \(rows)")
+        }
     }
 
     // MARK: - Helpers

--- a/Sources/Qwen3ASR/CoreMLTextDecoder.swift
+++ b/Sources/Qwen3ASR/CoreMLTextDecoder.swift
@@ -269,9 +269,17 @@ public class CoreMLTextDecoder {
         case .float32:
             let p = src.dataPointer.assumingMemoryBound(to: Float.self)
             for j in 0..<hidden { dst[dstBase + j] = p[base + j * lastStride] }
+        case .double:
+            let p = src.dataPointer.assumingMemoryBound(to: Float64.self)
+            for j in 0..<hidden { dst[dstBase + j] = Float(p[base + j * lastStride]) }
         default:
-            let p = src.dataPointer.assumingMemoryBound(to: Float.self)
-            for j in 0..<hidden { dst[dstBase + j] = p[base + j * lastStride] }
+            // Never reinterpret an unknown dtype as Float32 — that is the
+            // defect this file already shipped once. Callers that can throw
+            // reject the dtype in ``validateEmbeddingSource`` before reaching
+            // here; this non-throwing path zero-fills instead, which surfaces
+            // as an obviously empty transcript rather than as the fluent
+            // fabrication a misread produces.
+            for j in 0..<hidden { dst[dstBase + j] = 0 }
         }
     }
 
@@ -468,9 +476,12 @@ public class CoreMLTextDecoder {
         case .float32:
             let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
             return ptr[i]
+        case .double:
+            let ptr = logits.dataPointer.assumingMemoryBound(to: Float64.self)
+            return Float(ptr[i])
         default:
-            let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
-            return ptr[i]
+            // See ``copyRow`` — an unknown dtype is not reinterpreted.
+            return -.infinity
         }
     }
 
@@ -511,16 +522,21 @@ public class CoreMLTextDecoder {
                     maxIdx = Int32(i)
                 }
             }
-        default:
-            let ptr = logits.dataPointer.assumingMemoryBound(to: Float.self)
+        case .double:
+            let ptr = logits.dataPointer.assumingMemoryBound(to: Float64.self)
             for i in 0..<vocab where i != skipIdx {
-                let val = ptr[i * lastStride]
+                let val = Float(ptr[i * lastStride])
                 if val.isNaN { nanCount += 1; continue }
                 if val > maxVal {
                     maxVal = val
                     maxIdx = Int32(i)
                 }
             }
+        default:
+            // See ``copyRow`` — an unknown dtype is not reinterpreted. Token 0
+            // is returned so the caller produces visibly wrong output instead
+            // of a plausible transcript decoded from misread memory.
+            return 0
         }
 
         return maxIdx
@@ -616,6 +632,17 @@ public class CoreMLTextDecoder {
     static func validateEmbeddingSource(
         _ embeddings: MLMultiArray, hidden: Int, requiredRows: Int
     ) throws {
+        switch embeddings.dataType {
+        case .float16, .float32, .double:
+            break
+        default:
+            throw AudioModelError.inferenceFailed(
+                operation: "CoreML audio embedding",
+                reason: "Unsupported embeddings dtype (raw \(embeddings.dataType.rawValue)) — "
+                    + "expected Float16, Float32 or Float64. Reading it as Float32 would "
+                    + "silently corrupt every value.")
+        }
+
         let shape = embeddings.shape.map { $0.intValue }
         guard let last = shape.last, last == hidden else {
             throw AudioModelError.inferenceFailed(

--- a/Sources/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR.swift
@@ -274,7 +274,39 @@ public class Qwen3ASRModel {
             ? Double(audio.count) / Double(sampleRate)
             : 0.0
         let effective = options.adaptedFor(audioDurationSeconds: durationSeconds)
+        return Self.catchingMLXErrors {
+            self.transcribeAdapted(audio: audio, sampleRate: sampleRate, options: effective)
+        }
+    }
 
+    /// Run `body`, converting an MLX failure into a diagnostic string rather
+    /// than a process kill.
+    ///
+    /// mlx-swift's default error handler calls `fatalError`, so *any* MLX
+    /// failure — a Metal allocation that fails under memory pressure, a bad
+    /// shape — terminates the host application with no way to intervene.
+    /// Tolerable for a CLI, wrong for an app: a transcription that cannot
+    /// complete should degrade to an error, not take the process with it.
+    /// `withError` scopes a handler that rethrows instead, and the string
+    /// form matches the convention ``CoreMLASRModel`` already uses.
+    ///
+    /// This does not make MLX errors less likely, only survivable.
+    static func catchingMLXErrors(_ body: () throws -> String) -> String {
+        do {
+            return try withError { try body() }
+        } catch {
+            return "[Qwen3ASR MLX error: \(error.localizedDescription)]"
+        }
+    }
+
+    /// Body of ``transcribe(audio:sampleRate:options:)``, split out so the
+    /// public entry point is nothing but the MLX guard around it. `options`
+    /// has already been length-adapted by the caller.
+    private func transcribeAdapted(
+        audio: [Float],
+        sampleRate: Int,
+        options: Qwen3DecodingOptions
+    ) -> String {
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
         let batchedFeatures = melFeatures.expandedDimensions(axis: 0)
         var audioEmbeds = audioEncoder(batchedFeatures)
@@ -286,10 +318,10 @@ public class Qwen3ASRModel {
         return generateText(
             audioEmbeds: audioEmbeds,
             textDecoder: textDecoder,
-            language: effective.language,
-            maxTokens: effective.maxTokens,
-            context: effective.context,
-            decodingOptions: effective
+            language: options.language,
+            maxTokens: options.maxTokens,
+            context: options.context,
+            decodingOptions: options
         )
     }
 
@@ -313,7 +345,18 @@ public class Qwen3ASRModel {
         let baseOptions = Qwen3DecodingOptions(
             maxTokens: maxTokens, language: language, context: context)
         let effective = baseOptions.adaptedFor(audioDurationSeconds: durationSeconds)
+        return Self.catchingMLXErrors {
+            self.transcribeLegacyAdapted(audio: audio, sampleRate: sampleRate, options: effective)
+        }
+    }
 
+    /// Body of the legacy ``transcribe(audio:sampleRate:language:maxTokens:context:)``
+    /// overload, split out for the same reason as ``transcribeAdapted``.
+    private func transcribeLegacyAdapted(
+        audio: [Float],
+        sampleRate: Int,
+        options effective: Qwen3DecodingOptions
+    ) -> String {
         // Extract mel features
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
 
@@ -1002,7 +1045,11 @@ public class Qwen3ASRModel {
 
         // Pull logits to CPU. `logits` is [1, 1, vocabSize]; after squeeze
         // and conversion we have a plain `[Float]` of length vocabSize.
-        let flat = logits.squeezed().asType(.float32)
+        // No explicit `asType(.float32)`: `asArray(Float.self)` already casts
+        // when the dtype differs, so that cast allocated a second full-vocab
+        // array (151,936 floats, ~608 KB) per generated token and then copied
+        // it again. Behaviour is identical without it.
+        let flat = logits.squeezed()
         let vocabSize = flat.size
         var scores: [Float] = flat.asArray(Float.self)
         precondition(scores.count == vocabSize, "pickNextToken: vocab size mismatch")
@@ -1171,6 +1218,38 @@ internal enum Qwen3ASRMemory {
         return max(0, min(fourGB, quarterRAM))
     }
 
+    /// True when the platform's real ceiling is the app's own jetsam budget
+    /// rather than the machine's RAM.
+    static var isMemoryConstrainedPlatform: Bool {
+        #if os(macOS)
+        return false
+        #else
+        return true
+        #endif
+    }
+
+    /// MLX cache ceiling to apply at load, or `nil` to leave the process
+    /// default alone.
+    ///
+    /// macOS caps only the 1.7B variant — the case observed to swap (see
+    /// ``cacheLimitForLarge``). Memory-constrained platforms cap every
+    /// variant, because MLX's default cache limit tracks the *device's*
+    /// recommended working set, which on a phone bears no relation to what
+    /// the app may hold before jetsam terminates it. Under sustained
+    /// decoding even the 0.6B model can grow its scratch pool past that
+    /// budget, and nothing was bounding it.
+    ///
+    /// The bound reuses the 1.7B formula: a ceiling where there was none,
+    /// not a figure tuned against device telemetry.
+    static func cacheLimitBytes(
+        isLargeModel: Bool,
+        isMemoryConstrainedPlatform: Bool,
+        physicalMemoryBytes: Int
+    ) -> Int? {
+        guard isLargeModel || isMemoryConstrainedPlatform else { return nil }
+        return cacheLimitForLarge(physicalMemoryBytes: physicalMemoryBytes)
+    }
+
     /// True when the 1.7B variant should print the soft RAM warning. Total
     /// (not available) RAM is the pragmatic signal — see threshold doc.
     static func shouldWarnForLarge(physicalMemoryBytes: UInt64) -> Bool {
@@ -1305,9 +1384,12 @@ public extension Qwen3ASRModel {
         // of the loaded ASR. Stacks correctly across multiple ASR
         // instances: each save captures whatever was active when it
         // loaded, and each unload pops its own saved value.
-        if modelSize == .large {
-            let physical = Int(ProcessInfo.processInfo.physicalMemory)
-            let newCap = Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: physical)
+        let physical = Int(ProcessInfo.processInfo.physicalMemory)
+        if let newCap = Qwen3ASRMemory.cacheLimitBytes(
+            isLargeModel: modelSize == .large,
+            isMemoryConstrainedPlatform: Qwen3ASRMemory.isMemoryConstrainedPlatform,
+            physicalMemoryBytes: physical)
+        {
             // Only apply the cap if it would lower the current limit —
             // never raise a limit a caller has already chosen for itself.
             let currentLimit = MLX.Memory.cacheLimit

--- a/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
+++ b/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
@@ -192,5 +192,31 @@ final class CoreMLEmbeddingExtractionTests: XCTestCase {
             try CoreMLTextDecoder.extractRows(
                 from: embeddings, count: 5, hidden: hidden))
     }
+
+    // MARK: - Encoder output_length clamp
+
+    /// The second route to the same fault: the encoder reports its real
+    /// audio-token count in-graph, and every consumer uses it as an index
+    /// bound. A count larger than the tensor holds must be clamped, not
+    /// handed on.
+    func testReportedLengthIsClampedToTensorExtent() {
+        let shape = [1, 390, 1024]
+
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(260, embeddingShape: shape), 260,
+                       "a length inside the tensor passes through untouched")
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(390, embeddingShape: shape), 390,
+                       "the full extent is legal")
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(391, embeddingShape: shape), 390,
+                       "one past the extent clamps rather than overruns")
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(100_000, embeddingShape: shape), 390,
+                       "a wildly wrong report clamps too")
+    }
+
+    func testNegativeOrDegenerateLengthsClampToZero() {
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(-1, embeddingShape: [1, 390, 1024]), 0)
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(5, embeddingShape: [1024]), 0,
+                       "a shape with no token axis can supply nothing")
+        XCTAssertEqual(CoreMLASREncoder.clampOutputLength(5, embeddingShape: []), 0)
+    }
 }
 #endif

--- a/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
+++ b/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
@@ -1,0 +1,196 @@
+#if canImport(CoreML)
+import CoreML
+import XCTest
+
+@testable import Qwen3ASR
+
+/// Regression tests for the CoreML audio-embedding extraction path.
+///
+/// The bug these pin: `audioEmbeddingFromMultiArray` read the encoder's
+/// `audio_embeddings` output with `assumingMemoryBound(to: Float.self)`.
+/// That output is **Float16** `[1, 390, 1024]`, so the read walked the
+/// buffer at twice the real element stride — every value was two Float16s
+/// reinterpreted as one Float32, and row 195 of 390 was the first read
+/// entirely past the end of the allocation (~15 s of audio, since the
+/// encoder emits 13 tokens per 100 mel frames). Under 15 s it returned
+/// garbage silently; over 15 s it segfaulted.
+///
+/// No model download and no GPU: every case builds its own MLMultiArray.
+final class CoreMLEmbeddingExtractionTests: XCTestCase {
+
+    private let hidden = 8
+
+    // MARK: - Helpers
+
+    /// Contiguous `[1, rows, hidden]` array whose value at (row, col) is
+    /// `Float(row * hidden + col)` — distinct per slot so a misread is
+    /// visible, and small enough to be exactly representable in Float16
+    /// (integers are exact only up to 2048) so these assert on the
+    /// extraction rather than on half-precision rounding.
+    private func makeArray(rows: Int, dataType: MLMultiArrayDataType) throws -> MLMultiArray {
+        let a = try MLMultiArray(shape: [1, rows as NSNumber, hidden as NSNumber],
+                                 dataType: dataType)
+        for r in 0..<rows {
+            for c in 0..<hidden {
+                a[r * hidden + c] = NSNumber(value: Float(r * hidden + c))
+            }
+        }
+        return a
+    }
+
+    private func expected(row: Int) -> [Float] {
+        (0..<hidden).map { Float(row * hidden + $0) }
+    }
+
+    private func values(of array: MLMultiArray) -> [Float] {
+        (0..<array.count).map { array[$0].floatValue }
+    }
+
+    // MARK: - Float16 source (the shipped encoder's dtype)
+
+    /// The core regression: a Float16 source must be *converted*, not
+    /// reinterpreted. Pre-fix this returned garbage for every row.
+    func testFloat16SourceConvertsRatherThanReinterprets() throws {
+        let rows = 6
+        let embeddings = try makeArray(rows: rows, dataType: .float16)
+
+        for row in 0..<rows {
+            let slice = try CoreMLTextDecoder.extractRow(
+                from: embeddings, at: row, hidden: hidden)
+            XCTAssertEqual(values(of: slice), expected(row: row),
+                           "row \(row) misread from a Float16 buffer")
+        }
+    }
+
+    /// Reading a Float16 buffer as Float32 exhausts it at the halfway row
+    /// (here row 32 of 64), which is what segfaulted on device. The last row
+    /// must read correctly and in bounds.
+    func testFloat16LastRowStaysInBounds() throws {
+        let rows = 64
+        let embeddings = try makeArray(rows: rows, dataType: .float16)
+
+        let slice = try CoreMLTextDecoder.extractRow(
+            from: embeddings, at: rows - 1, hidden: hidden)
+        XCTAssertEqual(values(of: slice), expected(row: rows - 1))
+    }
+
+    // MARK: - Float32 source (unchanged behaviour)
+
+    func testFloat32SourceUnchanged() throws {
+        let rows = 6
+        let embeddings = try makeArray(rows: rows, dataType: .float32)
+
+        for row in 0..<rows {
+            let slice = try CoreMLTextDecoder.extractRow(
+                from: embeddings, at: row, hidden: hidden)
+            XCTAssertEqual(values(of: slice), expected(row: row))
+        }
+    }
+
+    // MARK: - Padded strides (the other ANE output shape)
+
+    /// ANE can hand back rows padded to an alignment boundary. Reading with
+    /// `index * hidden` would skew progressively further into the padding.
+    func testPaddedRowStrideIsHonoured() throws {
+        let rows = 5
+        let paddedStride = hidden + 3
+        var storage = [Float](repeating: -1, count: rows * paddedStride)
+        for r in 0..<rows {
+            for c in 0..<hidden {
+                storage[r * paddedStride + c] = Float(r * hidden + c)
+            }
+        }
+
+        try storage.withUnsafeMutableBufferPointer { buf in
+            let embeddings = try MLMultiArray(
+                dataPointer: buf.baseAddress!,
+                shape: [1, rows as NSNumber, hidden as NSNumber],
+                dataType: .float32,
+                strides: [(rows * paddedStride) as NSNumber, paddedStride as NSNumber, 1],
+                deallocator: nil)
+
+            for row in 0..<rows {
+                let slice = try CoreMLTextDecoder.extractRow(
+                    from: embeddings, at: row, hidden: hidden)
+                XCTAssertEqual(values(of: slice), expected(row: row),
+                               "row \(row) misread from a padded-stride buffer")
+            }
+        }
+    }
+
+    // MARK: - Bounds
+
+    func testRowCountBeyondBufferIsRejected() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.validateEmbeddingSource(
+                embeddings, hidden: hidden, requiredRows: 5),
+            "a length claim past the tensor extent must throw, not read past the buffer")
+        XCTAssertNoThrow(
+            try CoreMLTextDecoder.validateEmbeddingSource(
+                embeddings, hidden: hidden, requiredRows: 4))
+    }
+
+    func testWidthMismatchIsRejected() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.validateEmbeddingSource(
+                embeddings, hidden: hidden + 1, requiredRows: 1),
+            "a hidden-size disagreement must throw rather than stride wrongly")
+    }
+
+    func testNegativeIndexIsRejected() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.extractRow(
+                from: embeddings, at: -1, hidden: hidden))
+    }
+
+    func testIndexPastLastRowIsRejected() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.extractRow(
+                from: embeddings, at: 4, hidden: hidden))
+    }
+
+    // MARK: - Bulk extraction
+
+    /// `transcribeWithoutMLX` now bulk-extracts every audio row in one call.
+    /// It must produce the same values, row-major, that the per-row helper
+    /// returns — otherwise the batched prefill feeds the decoder garbage.
+    func testBulkExtractionMatchesPerRowExtraction() throws {
+        let rows = 10
+        let embeddings = try makeArray(rows: rows, dataType: .float16)
+
+        let flat = try CoreMLTextDecoder.extractRows(
+            from: embeddings, count: rows, hidden: hidden)
+        XCTAssertEqual(flat.count, rows * hidden)
+
+        for row in 0..<rows {
+            let start = row * hidden
+            XCTAssertEqual(Array(flat[start..<(start + hidden)]), expected(row: row),
+                           "bulk row \(row) disagrees with the per-row read")
+        }
+    }
+
+    func testBulkExtractionOfZeroRowsIsEmpty() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        let flat = try CoreMLTextDecoder.extractRows(
+            from: embeddings, count: 0, hidden: hidden)
+        XCTAssertTrue(flat.isEmpty)
+    }
+
+    func testBulkExtractionPastBufferIsRejected() throws {
+        let embeddings = try makeArray(rows: 4, dataType: .float16)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.extractRows(
+                from: embeddings, count: 5, hidden: hidden))
+    }
+}
+#endif

--- a/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
+++ b/Tests/Qwen3ASRTests/CoreMLEmbeddingExtractionTests.swift
@@ -193,6 +193,66 @@ final class CoreMLEmbeddingExtractionTests: XCTestCase {
                 from: embeddings, count: 5, hidden: hidden))
     }
 
+    // MARK: - Unexpected dtypes are refused, never reinterpreted
+
+    /// Float64 is the third dtype CoreML can emit for a float tensor, and
+    /// reading it through a `Float` pointer is the same defect mirrored:
+    /// half the stride, so the values are wrong while staying inside the
+    /// allocation. It must be converted like Float16 is.
+    func testFloat64SourceIsConvertedNotReinterpreted() throws {
+        let rows = 6
+        let embeddings = try makeArray(rows: rows, dataType: .double)
+
+        for row in 0..<rows {
+            let slice = try CoreMLTextDecoder.extractRow(
+                from: embeddings, at: row, hidden: hidden)
+            XCTAssertEqual(values(of: slice), expected(row: row),
+                           "row \(row) misread from a Float64 buffer")
+        }
+
+        let flat = try CoreMLTextDecoder.extractRows(
+            from: embeddings, count: rows, hidden: hidden)
+        for row in 0..<rows {
+            let start = row * hidden
+            XCTAssertEqual(Array(flat[start..<(start + hidden)]), expected(row: row))
+        }
+    }
+
+    /// A dtype we cannot read must be rejected at the boundary rather than
+    /// reinterpreted. The old `default:` branches read *any* dtype through a
+    /// `Float` pointer, which is how a Float16 buffer became fluent nonsense.
+    func testUnreadableDtypeIsRejected() throws {
+        let embeddings = try MLMultiArray(
+            shape: [1, 4 as NSNumber, hidden as NSNumber], dataType: .int32)
+
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.validateEmbeddingSource(
+                embeddings, hidden: hidden, requiredRows: 4),
+            "an unreadable dtype must throw, not be reinterpreted as Float32")
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.extractRow(from: embeddings, at: 0, hidden: hidden))
+        XCTAssertThrowsError(
+            try CoreMLTextDecoder.extractRows(from: embeddings, count: 4, hidden: hidden))
+    }
+
+    /// `copyRow` cannot throw — it runs inside a non-throwing closure. Its
+    /// fallback must still not reinterpret memory; it zero-fills, which
+    /// surfaces as an obviously empty transcript instead of a plausible one
+    /// decoded from misread bytes.
+    func testCopyRowFallbackZeroFillsInsteadOfReinterpreting() throws {
+        let embeddings = try MLMultiArray(
+            shape: [1, 2 as NSNumber, hidden as NSNumber], dataType: .int32)
+        for i in 0..<(2 * hidden) { embeddings[i] = NSNumber(value: Int32(i + 1)) }
+
+        var out = [Float](repeating: .nan, count: hidden)
+        out.withUnsafeMutableBufferPointer { buf in
+            CoreMLTextDecoder.copyRow(from: embeddings, sourceRow: 1, hidden: hidden,
+                                      to: buf.baseAddress!, destSlot: 0)
+        }
+        XCTAssertEqual(out, [Float](repeating: 0, count: hidden),
+                       "the fallback reinterpreted memory instead of zero-filling")
+    }
+
     // MARK: - Encoder output_length clamp
 
     /// The second route to the same fault: the encoder reports its real

--- a/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
@@ -68,5 +68,56 @@ final class E2ECoreMLASRTests: XCTestCase {
                           "Missing expected word '\(word)' — raw=\"\(result)\"")
         }
     }
+
+    /// The MLX-free path, which had no coverage at all until it shipped a
+    /// SIGSEGV. It reads the encoder's Float16 `audio_embeddings` output;
+    /// reading that as Float32 corrupted every embedding and ran off the
+    /// end of the buffer past audio token 194 (~15 s). This asserts the
+    /// same transcript `transcribe()` produces, so a dtype or stride
+    /// regression shows up as wrong text rather than as a crash on
+    /// somebody's phone.
+    func testMLXFreeTranscriptionMatchesMLXPath() async throws {
+        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
+            throw XCTSkip("test_audio.wav not found in Qwen3ASRTests resources")
+        }
+
+        let asr: CoreMLASRModel
+        do {
+            asr = try await CoreMLASRModel.fromPretrained { _, _ in }
+        } catch {
+            throw XCTSkip("CoreML ASR bundle unavailable: \(error)")
+        }
+
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
+        let targetSampleRate = 16000
+        let audio: [Float]
+        if sampleRate != targetSampleRate {
+            audio = AudioFileLoader.resample(samples, from: sampleRate, to: targetSampleRate)
+        } else {
+            audio = samples
+        }
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let result = try asr.transcribeWithoutMLX(
+            audio: audio, sampleRate: targetSampleRate, language: "english")
+        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        let audioMs = Double(audio.count) / Double(targetSampleRate) * 1000
+
+        let normalised = result
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .joined(separator: " ")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        print("[COREML-ASR-NOMLX] raw=\"\(result)\"  normalised=\"\(normalised)\"")
+        print(String(format: "[COREML-ASR-NOMLX-PERF] transcribe=%.0fms audio=%.0fms rtf=%.3f",
+                     elapsedMs, audioMs, elapsedMs / audioMs))
+
+        XCTAssertFalse(result.isEmpty, "MLX-free transcription should not be empty")
+        for word in ["guarantee", "replacement", "shipped", "tomorrow"] {
+            XCTAssertTrue(normalised.contains(word),
+                          "Missing expected word '\(word)' — raw=\"\(result)\"")
+        }
+    }
 }
 #endif

--- a/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
@@ -131,6 +131,107 @@ final class E2ECoreMLASRTests: XCTestCase {
         }
     }
 
+    /// `test_audio.wav` is 20 s but the sentence occupies only seconds
+    /// 5–9; the rest is digital silence. Slicing a prefix therefore yields
+    /// silence, not short speech. This returns just the spoken region so a
+    /// clip of any target length can be built around known content.
+    private func speechRegion(of fixture: [Float]) -> [Float] {
+        let start = Int(4.5 * 16000)
+        let end = min(Int(9.5 * 16000), fixture.count)
+        return Array(fixture[start..<end])
+    }
+
+    /// The spoken region padded with silence to `seconds`. Trailing silence
+    /// is what the fixture itself contains and what the encoder pads with,
+    /// so the expected transcript is identical at every length — only the
+    /// audio-token count changes.
+    private func clip(_ seconds: Double, from fixture: [Float]) -> [Float] {
+        let speech = speechRegion(of: fixture)
+        let target = Int(seconds * 16000)
+        if speech.count >= target { return Array(speech.prefix(target)) }
+        return speech + [Float](repeating: 0, count: target - speech.count)
+    }
+
+    /// Bracket the row-195 cliff with real weights.
+    ///
+    /// The defect was length-dependent in a way that hid it: below ~15 s the
+    /// bad read stayed inside the allocation and returned quiet garbage;
+    /// above it, it left the buffer. A single fixture length cannot see
+    /// that. Every clip here carries the *same* sentence and differs only in
+    /// audio-token count, so the expected transcript is constant across the
+    /// boundary — the two extraction routes must agree with each other and
+    /// both must still contain the sentence.
+    ///
+    /// Pre-fix this fails on both counts: below the cliff the routes
+    /// diverge, above it the MLX-free path returns empty or faults.
+    func testExtractionAgreesAcrossTheLengthCliff() async throws {
+        let base = try loadFixture("test_audio")
+        let asr = try await loadModel()
+
+        // Two lengths well below the ~15 s cliff, two above it.
+        for seconds in [5.0, 12.0, 18.0, 25.0] {
+            let audio = clip(seconds, from: base)
+            XCTAssertEqual(Double(audio.count) / 16000.0, seconds, accuracy: 0.01)
+
+            let viaMLX = try asr.transcribe(
+                audio: audio, sampleRate: 16000, language: "english")
+            let viaCoreMLOnly = try asr.transcribeWithoutMLX(
+                audio: audio, sampleRate: 16000, language: "english")
+
+            print("[COREML-ASR-SWEEP] \(seconds)s nomlx=\"\(viaCoreMLOnly)\"")
+
+            XCTAssertEqual(viaCoreMLOnly, viaMLX,
+                           "extraction routes disagree at \(seconds)s")
+
+            let normalised = normalise(viaCoreMLOnly)
+            for word in ["guarantee", "replacement", "shipped", "tomorrow"] {
+                XCTAssertTrue(normalised.contains(word),
+                              "\(seconds)s clip lost '\(word)' — raw=\"\(viaCoreMLOnly)\"")
+            }
+        }
+    }
+
+    /// The reporter's actual workload: one model instance, consecutive
+    /// segments in a loop. That exercises `resetCache()` and the decoder's
+    /// KV position reset between calls, which nothing else covers — every
+    /// other test transcribes once per instance.
+    ///
+    /// Interleaving lengths is the point. If state bled from a long segment
+    /// into the next call, the two identical long clips either side of a
+    /// short one would not produce identical text.
+    func testRepeatedSegmentsOnOneInstanceDoNotBleed() async throws {
+        let base = try loadFixture("test_audio")
+        let asr = try await loadModel()
+
+        let long = clip(24.0, from: base)
+        let short = clip(5.0, from: base)
+
+        let first = try asr.transcribeWithoutMLX(
+            audio: long, sampleRate: 16000, language: "english")
+        let interposed = try asr.transcribeWithoutMLX(
+            audio: short, sampleRate: 16000, language: "english")
+        let second = try asr.transcribeWithoutMLX(
+            audio: long, sampleRate: 16000, language: "english")
+        let interposedAgain = try asr.transcribeWithoutMLX(
+            audio: short, sampleRate: 16000, language: "english")
+
+        print("[COREML-ASR-REUSE] long=\"\(first)\" short=\"\(interposed)\"")
+
+        XCTAssertEqual(first, second,
+                       "the same clip gave different text after an intervening segment — "
+                       + "decoder state is bleeding across calls")
+        XCTAssertEqual(interposed, interposedAgain,
+                       "the short clip is not reproducible across repeated use of one instance")
+
+        for (label, text) in [("long", first), ("short", interposed)] {
+            let normalised = normalise(text)
+            for word in ["guarantee", "replacement", "shipped", "tomorrow"] {
+                XCTAssertTrue(normalised.contains(word),
+                              "\(label) clip lost '\(word)' after repeated use — raw=\"\(text)\"")
+            }
+        }
+    }
+
     /// `transcribeWithoutMLX` exists for one reason: to run where Metal
     /// eval would crash, i.e. iOS background execution. Nothing verified
     /// that it actually holds — and the doc comment on `transcribe()`

--- a/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
+++ b/Tests/Qwen3ASRTests/E2ECoreMLASRTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 import Foundation
 import AudioCommon
+import MLX
 @testable import Qwen3ASR
 
 /// End-to-end tests for the full CoreML ASR pipeline
@@ -69,54 +70,141 @@ final class E2ECoreMLASRTests: XCTestCase {
         }
     }
 
-    /// The MLX-free path, which had no coverage at all until it shipped a
-    /// SIGSEGV. It reads the encoder's Float16 `audio_embeddings` output;
-    /// reading that as Float32 corrupted every embedding and ran off the
-    /// end of the buffer past audio token 194 (~15 s). This asserts the
-    /// same transcript `transcribe()` produces, so a dtype or stride
-    /// regression shows up as wrong text rather than as a crash on
-    /// somebody's phone.
-    func testMLXFreeTranscriptionMatchesMLXPath() async throws {
-        guard let wavURL = Bundle.module.url(forResource: "test_audio", withExtension: "wav") else {
-            throw XCTSkip("test_audio.wav not found in Qwen3ASRTests resources")
-        }
+    // MARK: - MLX-free path
 
-        let asr: CoreMLASRModel
+    /// Load a fixture at 16 kHz.
+    private func loadFixture(_ name: String) throws -> [Float] {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "wav") else {
+            throw XCTSkip("\(name).wav not found in Qwen3ASRTests resources")
+        }
+        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: url)
+        return sampleRate == 16000
+            ? samples
+            : AudioFileLoader.resample(samples, from: sampleRate, to: 16000)
+    }
+
+    private func loadModel() async throws -> CoreMLASRModel {
         do {
-            asr = try await CoreMLASRModel.fromPretrained { _, _ in }
+            return try await CoreMLASRModel.fromPretrained { _, _ in }
         } catch {
             throw XCTSkip("CoreML ASR bundle unavailable: \(error)")
         }
+    }
 
-        let (samples, sampleRate) = try AudioFileLoader.loadWAV(url: wavURL)
-        let targetSampleRate = 16000
-        let audio: [Float]
-        if sampleRate != targetSampleRate {
-            audio = AudioFileLoader.resample(samples, from: sampleRate, to: targetSampleRate)
-        } else {
-            audio = samples
-        }
-
-        let start = CFAbsoluteTimeGetCurrent()
-        let result = try asr.transcribeWithoutMLX(
-            audio: audio, sampleRate: targetSampleRate, language: "english")
-        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
-        let audioMs = Double(audio.count) / Double(targetSampleRate) * 1000
-
-        let normalised = result
-            .lowercased()
+    private func normalise(_ text: String) -> String {
+        text.lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .joined(separator: " ")
             .replacingOccurrences(of: "  ", with: " ")
             .trimmingCharacters(in: .whitespaces)
-        print("[COREML-ASR-NOMLX] raw=\"\(result)\"  normalised=\"\(normalised)\"")
-        print(String(format: "[COREML-ASR-NOMLX-PERF] transcribe=%.0fms audio=%.0fms rtf=%.3f",
-                     elapsedMs, audioMs, elapsedMs / audioMs))
+    }
 
-        XCTAssertFalse(result.isEmpty, "MLX-free transcription should not be empty")
+    /// The MLX-free path, which had no coverage at all until it shipped a
+    /// SIGSEGV. It reads the encoder's Float16 `audio_embeddings` output;
+    /// reading that as Float32 corrupted every embedding and ran off the
+    /// end of the buffer past audio token 194 (~15 s).
+    ///
+    /// `transcribe()` and `transcribeWithoutMLX()` are two **independent**
+    /// readings of the same encoder buffer — `multiArrayToMLXArray` and
+    /// `copyRow`. Both widen Float16 exactly, feed the same CoreML models,
+    /// and take the same greedy argmax, so they must agree character for
+    /// character. Divergence means one of the two extraction routes has
+    /// regressed, which is precisely the failure this bug was.
+    func testMLXFreeTranscriptionMatchesMLXPath() async throws {
+        let audio = try loadFixture("test_audio")
+        let asr = try await loadModel()
+
+        let viaMLX = try asr.transcribe(audio: audio, sampleRate: 16000, language: "english")
+        let viaCoreMLOnly = try asr.transcribeWithoutMLX(
+            audio: audio, sampleRate: 16000, language: "english")
+
+        print("[COREML-ASR-NOMLX] mlx=\"\(viaMLX)\"  nomlx=\"\(viaCoreMLOnly)\"")
+
+        XCTAssertFalse(viaCoreMLOnly.isEmpty, "MLX-free transcription should not be empty")
+        XCTAssertEqual(viaCoreMLOnly, viaMLX,
+                       "the two extraction routes read the same buffer and must agree")
+
+        let normalised = normalise(viaCoreMLOnly)
         for word in ["guarantee", "replacement", "shipped", "tomorrow"] {
             XCTAssertTrue(normalised.contains(word),
-                          "Missing expected word '\(word)' — raw=\"\(result)\"")
+                          "Missing expected word '\(word)' — raw=\"\(viaCoreMLOnly)\"")
+        }
+    }
+
+    /// `transcribeWithoutMLX` exists for one reason: to run where Metal
+    /// eval would crash, i.e. iOS background execution. Nothing verified
+    /// that it actually holds — and the doc comment on `transcribe()`
+    /// claimed the same property while quietly round-tripping mel features
+    /// and encoder output through MLXArray.
+    ///
+    /// This pins the invariant with MLX's own accounting: the MLX-free path
+    /// must not move MLX's peak allocation at all, and `transcribe()` must,
+    /// which is what makes the assertion meaningful rather than vacuous.
+    func testOnlyTheMLXFreePathAvoidsMLXAllocation() async throws {
+        let audio = try loadFixture("test_audio")
+        let asr = try await loadModel()
+
+        // Warm both paths first so one-off MLX setup isn't charged to the
+        // measured run.
+        _ = try asr.transcribe(audio: audio, sampleRate: 16000, language: "english")
+        _ = try asr.transcribeWithoutMLX(audio: audio, sampleRate: 16000, language: "english")
+
+        MLX.Memory.peakMemory = 0  // setter resets; newValue ignored
+        let baseline = MLX.Memory.peakMemory
+        _ = try asr.transcribeWithoutMLX(audio: audio, sampleRate: 16000, language: "english")
+        let afterMLXFree = MLX.Memory.peakMemory
+
+        MLX.Memory.peakMemory = 0
+        _ = try asr.transcribe(audio: audio, sampleRate: 16000, language: "english")
+        let afterMLXPath = MLX.Memory.peakMemory
+
+        print("[COREML-ASR-MLXMEM] baseline=\(baseline) nomlx=\(afterMLXFree) mlx=\(afterMLXPath)")
+
+        XCTAssertEqual(afterMLXFree, baseline,
+                       "transcribeWithoutMLX allocated MLX memory — it is no longer MLX-free, "
+                       + "and no longer safe in the background context it exists for")
+        XCTAssertGreaterThan(afterMLXPath, baseline,
+                             "transcribe() is expected to allocate through MLX; if it stopped, "
+                             + "this test has lost its teeth and the comparison above proves nothing")
+    }
+
+    /// Drive the audio-token count to the very top of the encoder's fixed
+    /// 390-token output so the extraction reads the last rows of the buffer.
+    ///
+    /// The 20 s fixture only reaches ~260 tokens. A ~29.5 s clip reaches
+    /// ~384, leaving six rows of headroom — the strongest bounds assurance
+    /// available against real weights, and far past the row-195 cliff where
+    /// the old Float32 read left the allocation. A regression here faults or
+    /// returns garbage rather than quietly passing.
+    func testMLXFreePathAtEncoderTokenLimit() async throws {
+        var audio = try loadFixture("test_audio")
+        audio += try loadFixture("kokoro_continuous_stitched")
+
+        // The encoder's fixed mel shape tops out at 30 s; stay just inside.
+        let maxSamples = Int(29.5 * 16000)
+        XCTAssertGreaterThan(audio.count, maxSamples,
+                             "fixtures should concatenate to more than the cap so the trim is real")
+        audio = Array(audio.prefix(maxSamples))
+
+        let asr = try await loadModel()
+
+        let viaMLX = try asr.transcribe(audio: audio, sampleRate: 16000, language: "english")
+        let viaCoreMLOnly = try asr.transcribeWithoutMLX(
+            audio: audio, sampleRate: 16000, language: "english")
+
+        print("[COREML-ASR-LIMIT] nomlx=\"\(viaCoreMLOnly)\"")
+
+        XCTAssertFalse(viaCoreMLOnly.isEmpty,
+                       "a near-max-length clip should still transcribe")
+        XCTAssertEqual(viaCoreMLOnly, viaMLX,
+                       "the two extraction routes must agree at the top of the buffer too")
+
+        // The first 20 s is the known fixture, so its content must survive
+        // even though the tail is unrelated speech.
+        let normalised = normalise(viaCoreMLOnly)
+        for word in ["guarantee", "replacement", "shipped", "tomorrow"] {
+            XCTAssertTrue(normalised.contains(word),
+                          "Missing expected word '\(word)' — raw=\"\(viaCoreMLOnly)\"")
         }
     }
 }

--- a/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import MLX
+import MLXCommon
 import Foundation
 @testable import Qwen3ASR
 
@@ -8,6 +9,89 @@ import Foundation
 /// formatter. They are pure — no model download, no GPU — so they run on
 /// every CI shard.
 final class Qwen3MemoryGuardTests: XCTestCase {
+
+    // MARK: - Platform-aware cache ceiling (#479 hardening)
+
+    /// On macOS only the 1.7B variant is capped — the case observed to swap.
+    /// Leaving the 0.6B alone preserves existing desktop behaviour.
+    func testDesktopCapsOnlyTheLargeVariant() {
+        let sixteenGB = 16 * 1024 * 1024 * 1024
+
+        XCTAssertNil(
+            Qwen3ASRMemory.cacheLimitBytes(
+                isLargeModel: false, isMemoryConstrainedPlatform: false,
+                physicalMemoryBytes: sixteenGB),
+            "the 0.6B model on a Mac should keep MLX's default cache limit")
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitBytes(
+                isLargeModel: true, isMemoryConstrainedPlatform: false,
+                physicalMemoryBytes: sixteenGB),
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: sixteenGB))
+    }
+
+    /// On a memory-constrained platform every variant is capped. MLX's
+    /// default tracks the device's recommended working set, which has no
+    /// relation to the app's jetsam budget, so the small model was running
+    /// with no ceiling at all on iOS.
+    func testConstrainedPlatformCapsEveryVariant() {
+        let twelveGB = 12 * 1024 * 1024 * 1024
+        let expected = Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: twelveGB)
+
+        for isLarge in [false, true] {
+            XCTAssertEqual(
+                Qwen3ASRMemory.cacheLimitBytes(
+                    isLargeModel: isLarge, isMemoryConstrainedPlatform: true,
+                    physicalMemoryBytes: twelveGB),
+                expected,
+                "isLargeModel=\(isLarge) should be capped on a constrained platform")
+        }
+    }
+
+    // MARK: - Wired-memory pinning policy (#479 hardening)
+
+    /// Pinning 90% of the *device* working set is a macOS policy. On iOS
+    /// what kills the app is its own jetsam limit, and wired pages are not
+    /// reclaimable, so the default there is to pin nothing.
+    func testPinFractionZeroMeansNoWiredLimit() {
+        XCTAssertNil(MetalBudget.wiredLimit(workingSet: 8 * 1024 * 1024 * 1024, fraction: 0),
+                     "a zero fraction must set no wired limit at all")
+        XCTAssertNil(MetalBudget.wiredLimit(workingSet: 0, fraction: 0.9),
+                     "an unknown working set must set no wired limit")
+        XCTAssertEqual(MetalBudget.wiredLimit(workingSet: 1000, fraction: 0.9), 900)
+    }
+
+    #if os(macOS)
+    func testDesktopStillPinsNinetyPercent() {
+        XCTAssertEqual(MetalBudget.defaultPinFraction, 0.9,
+                       "macOS behaviour must be unchanged")
+    }
+    #else
+    func testConstrainedPlatformPinsNothingByDefault() {
+        XCTAssertEqual(MetalBudget.defaultPinFraction, 0.0)
+    }
+    #endif
+
+    // MARK: - MLX errors are survivable (#479 hardening)
+
+    /// mlx-swift's default handler calls `fatalError`, so any MLX failure
+    /// took the host process with it. Transcription must degrade to a
+    /// diagnostic string instead.
+    func testMLXErrorsBecomeADiagnosticStringNotAProcessKill() {
+        struct Boom: Error, LocalizedError {
+            var errorDescription: String? { "simulated MLX failure" }
+        }
+
+        XCTAssertEqual(
+            Qwen3ASRModel.catchingMLXErrors { "transcript" },
+            "transcript",
+            "the guard must be transparent when nothing fails")
+
+        let result = Qwen3ASRModel.catchingMLXErrors { throw Boom() }
+        XCTAssertTrue(result.hasPrefix("[Qwen3ASR MLX error:"),
+                      "a failure must surface as a diagnostic, got: \(result)")
+        XCTAssertTrue(result.contains("simulated MLX failure"),
+                      "the diagnostic must carry the underlying reason")
+    }
 
     // MARK: - cacheLimitForLarge
 

--- a/docs/inference/qwen3-asr-inference.md
+++ b/docs/inference/qwen3-asr-inference.md
@@ -166,7 +166,23 @@ The 8× conv stride downsamples 3000 mel frames to up to 390 audio tokens. For s
 
 ### Swift consumer
 
-`CoreMLEncoder.encode(_:)` returns `(embeddings: MLXArray, outputLength: Int)`. `CoreMLASRModel.transcribe` uses `outputLength` directly as `numAudioTokens` when chunking the audio prefill into the decoder; this replaces the previous `ceil(realMelFrames / 8)` heuristic with the model-reported truth.
+`CoreMLEncoder.encode(_:)` returns `(embeddings: MLXArray, outputLength: Int)`. `CoreMLASRModel.transcribe` uses `outputLength` directly as `numAudioTokens` when chunking the audio prefill into the decoder; this replaces the previous `ceil(realMelFrames / 8)` heuristic with the model-reported truth. `outputLength` is clamped to the embeddings tensor's own token extent, so a re-export whose in-graph length formula outran its output tensor throws instead of handing callers an out-of-range index.
+
+### Consuming `audio_embeddings`
+
+`audio_embeddings` is **Float16**, and ANE may hand it back with padded row strides. Never read it with `assumingMemoryBound(to: Float.self)` — that walks the buffer at twice the real element stride, which both corrupts every value and runs off the end of the allocation at row 195 of 390 (~15 s of audio). Go through one of:
+
+| Entry point | Use when |
+|---|---|
+| `CoreMLTextDecoder.audioEmbeddingsToFloatArray(_:count:)` | Bulk: the whole audio run at once, for batched prefill. This is what `transcribeWithoutMLX` uses. |
+| `CoreMLTextDecoder.audioEmbeddingFromMultiArray(_:at:)` | A single row. |
+| `CoreMLEncoder.encode(_:)` (MLXArray overload) | The MLX path — `multiArrayToMLXArray` converts. |
+
+All three are dtype- and stride-aware and bounds-check against the tensor's real extent.
+
+### Which path is MLX-free
+
+Only `CoreMLASRModel.transcribeWithoutMLX(...)` (and its wrapper `transcribeBackgroundSafe(...)`) is free of MLXArray operations end to end, so it is the one that is safe under iOS background execution. `CoreMLASRModel.transcribe(...)` dispatches all three models through CoreML but still round-trips through MLXArray for mel extraction and encoder output, both of which evaluate on Metal.
 
 ### Why the rebuild
 


### PR DESCRIPTION
Fixes #480.

## What changed

The encoder's `audio_embeddings` output is **Float16** `[1, 390, 1024]` — the inference doc already said so. `audioEmbeddingFromMultiArray` read it with `assumingMemoryBound(to: Float.self)`, walking the buffer at twice the real element stride. Every value came back as two Float16s reinterpreted as one Float32, and row 195 of 390 was the first read entirely past the end of the allocation: ~15 s of audio, since the encoder emits 13 tokens per 100 mel frames.

That gives the defect two faces, which is why the reporter saw both. Under 15 s it stays in bounds and returns garbage silently. Over 15 s it reads off the end — whether that faults depends on what follows the buffer.

Reproduced locally on the 20 s E2E fixture: the pre-fix read returns an **empty transcript**, because the corrupted embeddings make the decoder emit `<|im_end|>` immediately. It doesn't segfault on macOS only because the overrun stays inside a mapped page. The reporter's "several pieces transcribed successfully" were wrong too, not just the crashing ones.

## The fix

Not a bounds check — `CoreMLTextDecoder.copyRow` has been dtype- and stride-aware all along, and its own comment documents this exact hazard. The audio-embedding extraction just wasn't using it. Everything now goes through it.

While there, `transcribeWithoutMLX` bulk-extracts once and prefills in batched chunks like `transcribe()` already did, instead of one fixed-T ANE dispatch per audio token (~300 for a 24 s clip). The MLX-free path goes from **0.074 to 0.064 RTF** — now marginally faster than the MLX path.

Also:
- Bounds validation on every extraction entry point: a bad shape, or a length claim past the tensor extent, throws instead of reading past the buffer.
- `output_length` clamped to the embeddings tensor's own token extent.
- Same raw pointer read fixed in `decoderPrefill(embeddings:realCount:)` — safe for its in-repo caller, which passes Float32, but a trap for any external one.
- Two doc comments corrected. `transcribe()` claimed to run without MLX. It dispatches all three models through CoreML but still round-trips through MLXArray for mel extraction and encoder output, so it is **not** the background-safe path it advertised — which matters, because that's the workaround the reporter switched to.

## Why no test caught it

Worth stating plainly, because the gap is the more useful finding:

1. **The MLX-free path had no test of any kind.** Nothing in `Tests/` referenced `transcribeWithoutMLX`, `transcribeBackgroundSafe`, or `audioEmbeddingFromMultiArray`. `E2ECoreMLASRTests` only ever exercised `transcribe()` — the sibling that converts Float16 correctly. The path added specifically for iOS background execution was the one path never run.
2. **It was added without tests and merged that way** (`accb2d6`, March 2026), against this repo's own rule that every new feature ships with unit + E2E coverage.
3. **An E2E test alone would not have caught it in CI**, since CI skips E2E. The unit suite over the extraction is what actually guards this.

So this PR adds both. The unit suite (Float16, Float32, padded ANE strides, bounds) runs in CI; I verified it fails against the old implementation and passes against the new one, rather than assuming it would. The E2E case asserts the same transcript as the MLX path on a 20 s fixture — deliberately past the cliff, so it would have crashed before.

## Risk

Low. The MLX path is untouched apart from `decoderPrefill` now going through `copyRow`, which produces identical values for the Float32 buffer its caller passes. The one behaviour change is that malformed input now throws instead of reading out of bounds.

## Tests

`swift test --filter Qwen3ASRTests` — 220 passed, 0 failures, 5 skipped (E2E suites whose models aren't cached locally). Both CoreML ASR E2E cases ran against the real `aufklarer/Qwen3-ASR-CoreML` bundle and produce the expected transcript on the 20 s fixture.

## Follow-up, not in this PR

`assumingMemoryBound(to: Float.self)` appears at 63 sites across the package, several of them reading CoreML model outputs in other modules. Most are probably fine — the surrounding code often checks `dataType` — but the class of bug is identical and a sweep is worth its own issue.

#479 is a separate crash on the MLX path and is unaffected by this.
