### PR TITLE
harden(qwen3-asr): iOS memory policy and survivable MLX errors

### DIFF
--- a/Sources/MLXCommon/MetalBudget.swift
+++ b/Sources/MLXCommon/MetalBudget.swift
@@ -31,12 +31,41 @@ public enum MetalBudget {
         Memory.activeMemory
     }
 
+    /// Fraction of the recommended working set wired by default.
+    ///
+    /// macOS keeps 90%: there, wiring genuinely prevents paging under
+    /// memory pressure. iOS and the other embedded platforms pin nothing.
+    /// ``maxRecommendedWorkingSetSize`` describes the *device's* GPU budget,
+    /// but what terminates an app on those platforms is its own jetsam
+    /// limit, which is far smaller and treats wired pages as
+    /// non-reclaimable. Wiring 90% of the device working set there asks the
+    /// OS to hold memory it may need back in order to keep the app alive.
+    /// A caller that wants pinning anyway can still pass a fraction.
+    #if os(macOS)
+    public static let defaultPinFraction: Double = 0.9
+    #else
+    public static let defaultPinFraction: Double = 0.0
+    #endif
+
+    /// The wired limit implied by a working-set size and fraction, or `nil`
+    /// when no limit should be set at all.
+    ///
+    /// Pure, so the policy is testable on any platform rather than only on
+    /// the one running the tests.
+    public static func wiredLimit(workingSet: Int, fraction: Double) -> Int? {
+        guard fraction > 0, workingSet > 0 else { return nil }
+        return Int(Double(workingSet) * fraction)
+    }
+
     /// Pin GPU memory to prevent paging under pressure.
-    /// Uses 90% of recommended working set by default.
-    /// Only effective on macOS 15+ / iOS 18+.
+    /// Uses ``defaultPinFraction`` — 90% of the recommended working set on
+    /// macOS, nothing on iOS. Only effective on macOS 15+ / iOS 18+.
+    ///
+    /// Returns the previous wired limit, or 0 when no limit was applied.
     @discardableResult
-    public static func pinMemory(fraction: Double = 0.9) -> Int {
-        let limit = Int(Double(maxRecommendedWorkingSet) * fraction)
+    public static func pinMemory(fraction: Double = defaultPinFraction) -> Int {
+        guard let limit = wiredLimit(workingSet: maxRecommendedWorkingSet, fraction: fraction)
+        else { return 0 }
         var previous: size_t = 0
         mlx_set_wired_limit(&previous, size_t(limit))
         return Int(previous)

--- a/Sources/Qwen3ASR/Qwen3ASR.swift
+++ b/Sources/Qwen3ASR/Qwen3ASR.swift
@@ -274,7 +274,39 @@ public class Qwen3ASRModel {
             ? Double(audio.count) / Double(sampleRate)
             : 0.0
         let effective = options.adaptedFor(audioDurationSeconds: durationSeconds)
+        return Self.catchingMLXErrors {
+            self.transcribeAdapted(audio: audio, sampleRate: sampleRate, options: effective)
+        }
+    }
 
+    /// Run `body`, converting an MLX failure into a diagnostic string rather
+    /// than a process kill.
+    ///
+    /// mlx-swift's default error handler calls `fatalError`, so *any* MLX
+    /// failure — a Metal allocation that fails under memory pressure, a bad
+    /// shape — terminates the host application with no way to intervene.
+    /// Tolerable for a CLI, wrong for an app: a transcription that cannot
+    /// complete should degrade to an error, not take the process with it.
+    /// `withError` scopes a handler that rethrows instead, and the string
+    /// form matches the convention ``CoreMLASRModel`` already uses.
+    ///
+    /// This does not make MLX errors less likely, only survivable.
+    static func catchingMLXErrors(_ body: () throws -> String) -> String {
+        do {
+            return try withError { try body() }
+        } catch {
+            return "[Qwen3ASR MLX error: \(error.localizedDescription)]"
+        }
+    }
+
+    /// Body of ``transcribe(audio:sampleRate:options:)``, split out so the
+    /// public entry point is nothing but the MLX guard around it. `options`
+    /// has already been length-adapted by the caller.
+    private func transcribeAdapted(
+        audio: [Float],
+        sampleRate: Int,
+        options: Qwen3DecodingOptions
+    ) -> String {
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
         let batchedFeatures = melFeatures.expandedDimensions(axis: 0)
         var audioEmbeds = audioEncoder(batchedFeatures)
@@ -286,10 +318,10 @@ public class Qwen3ASRModel {
         return generateText(
             audioEmbeds: audioEmbeds,
             textDecoder: textDecoder,
-            language: effective.language,
-            maxTokens: effective.maxTokens,
-            context: effective.context,
-            decodingOptions: effective
+            language: options.language,
+            maxTokens: options.maxTokens,
+            context: options.context,
+            decodingOptions: options
         )
     }
 
@@ -313,7 +345,18 @@ public class Qwen3ASRModel {
         let baseOptions = Qwen3DecodingOptions(
             maxTokens: maxTokens, language: language, context: context)
         let effective = baseOptions.adaptedFor(audioDurationSeconds: durationSeconds)
+        return Self.catchingMLXErrors {
+            self.transcribeLegacyAdapted(audio: audio, sampleRate: sampleRate, options: effective)
+        }
+    }
 
+    /// Body of the legacy ``transcribe(audio:sampleRate:language:maxTokens:context:)``
+    /// overload, split out for the same reason as ``transcribeAdapted``.
+    private func transcribeLegacyAdapted(
+        audio: [Float],
+        sampleRate: Int,
+        options effective: Qwen3DecodingOptions
+    ) -> String {
         // Extract mel features
         let melFeatures = featureExtractor.process(audio, sampleRate: sampleRate)
 
@@ -1002,7 +1045,11 @@ public class Qwen3ASRModel {
 
         // Pull logits to CPU. `logits` is [1, 1, vocabSize]; after squeeze
         // and conversion we have a plain `[Float]` of length vocabSize.
-        let flat = logits.squeezed().asType(.float32)
+        // No explicit `asType(.float32)`: `asArray(Float.self)` already casts
+        // when the dtype differs, so that cast allocated a second full-vocab
+        // array (151,936 floats, ~608 KB) per generated token and then copied
+        // it again. Behaviour is identical without it.
+        let flat = logits.squeezed()
         let vocabSize = flat.size
         var scores: [Float] = flat.asArray(Float.self)
         precondition(scores.count == vocabSize, "pickNextToken: vocab size mismatch")
@@ -1171,6 +1218,38 @@ internal enum Qwen3ASRMemory {
         return max(0, min(fourGB, quarterRAM))
     }
 
+    /// True when the platform's real ceiling is the app's own jetsam budget
+    /// rather than the machine's RAM.
+    static var isMemoryConstrainedPlatform: Bool {
+        #if os(macOS)
+        return false
+        #else
+        return true
+        #endif
+    }
+
+    /// MLX cache ceiling to apply at load, or `nil` to leave the process
+    /// default alone.
+    ///
+    /// macOS caps only the 1.7B variant — the case observed to swap (see
+    /// ``cacheLimitForLarge``). Memory-constrained platforms cap every
+    /// variant, because MLX's default cache limit tracks the *device's*
+    /// recommended working set, which on a phone bears no relation to what
+    /// the app may hold before jetsam terminates it. Under sustained
+    /// decoding even the 0.6B model can grow its scratch pool past that
+    /// budget, and nothing was bounding it.
+    ///
+    /// The bound reuses the 1.7B formula: a ceiling where there was none,
+    /// not a figure tuned against device telemetry.
+    static func cacheLimitBytes(
+        isLargeModel: Bool,
+        isMemoryConstrainedPlatform: Bool,
+        physicalMemoryBytes: Int
+    ) -> Int? {
+        guard isLargeModel || isMemoryConstrainedPlatform else { return nil }
+        return cacheLimitForLarge(physicalMemoryBytes: physicalMemoryBytes)
+    }
+
     /// True when the 1.7B variant should print the soft RAM warning. Total
     /// (not available) RAM is the pragmatic signal — see threshold doc.
     static func shouldWarnForLarge(physicalMemoryBytes: UInt64) -> Bool {
@@ -1305,9 +1384,12 @@ public extension Qwen3ASRModel {
         // of the loaded ASR. Stacks correctly across multiple ASR
         // instances: each save captures whatever was active when it
         // loaded, and each unload pops its own saved value.
-        if modelSize == .large {
-            let physical = Int(ProcessInfo.processInfo.physicalMemory)
-            let newCap = Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: physical)
+        let physical = Int(ProcessInfo.processInfo.physicalMemory)
+        if let newCap = Qwen3ASRMemory.cacheLimitBytes(
+            isLargeModel: modelSize == .large,
+            isMemoryConstrainedPlatform: Qwen3ASRMemory.isMemoryConstrainedPlatform,
+            physicalMemoryBytes: physical)
+        {
             // Only apply the cap if it would lower the current limit —
             // never raise a limit a caller has already chosen for itself.
             let currentLimit = MLX.Memory.cacheLimit

--- a/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
+++ b/Tests/Qwen3ASRTests/Qwen3MemoryGuardTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import MLX
+import MLXCommon
 import Foundation
 @testable import Qwen3ASR
 
@@ -8,6 +9,89 @@ import Foundation
 /// formatter. They are pure — no model download, no GPU — so they run on
 /// every CI shard.
 final class Qwen3MemoryGuardTests: XCTestCase {
+
+    // MARK: - Platform-aware cache ceiling (#479 hardening)
+
+    /// On macOS only the 1.7B variant is capped — the case observed to swap.
+    /// Leaving the 0.6B alone preserves existing desktop behaviour.
+    func testDesktopCapsOnlyTheLargeVariant() {
+        let sixteenGB = 16 * 1024 * 1024 * 1024
+
+        XCTAssertNil(
+            Qwen3ASRMemory.cacheLimitBytes(
+                isLargeModel: false, isMemoryConstrainedPlatform: false,
+                physicalMemoryBytes: sixteenGB),
+            "the 0.6B model on a Mac should keep MLX's default cache limit")
+        XCTAssertEqual(
+            Qwen3ASRMemory.cacheLimitBytes(
+                isLargeModel: true, isMemoryConstrainedPlatform: false,
+                physicalMemoryBytes: sixteenGB),
+            Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: sixteenGB))
+    }
+
+    /// On a memory-constrained platform every variant is capped. MLX's
+    /// default tracks the device's recommended working set, which has no
+    /// relation to the app's jetsam budget, so the small model was running
+    /// with no ceiling at all on iOS.
+    func testConstrainedPlatformCapsEveryVariant() {
+        let twelveGB = 12 * 1024 * 1024 * 1024
+        let expected = Qwen3ASRMemory.cacheLimitForLarge(physicalMemoryBytes: twelveGB)
+
+        for isLarge in [false, true] {
+            XCTAssertEqual(
+                Qwen3ASRMemory.cacheLimitBytes(
+                    isLargeModel: isLarge, isMemoryConstrainedPlatform: true,
+                    physicalMemoryBytes: twelveGB),
+                expected,
+                "isLargeModel=\(isLarge) should be capped on a constrained platform")
+        }
+    }
+
+    // MARK: - Wired-memory pinning policy (#479 hardening)
+
+    /// Pinning 90% of the *device* working set is a macOS policy. On iOS
+    /// what kills the app is its own jetsam limit, and wired pages are not
+    /// reclaimable, so the default there is to pin nothing.
+    func testPinFractionZeroMeansNoWiredLimit() {
+        XCTAssertNil(MetalBudget.wiredLimit(workingSet: 8 * 1024 * 1024 * 1024, fraction: 0),
+                     "a zero fraction must set no wired limit at all")
+        XCTAssertNil(MetalBudget.wiredLimit(workingSet: 0, fraction: 0.9),
+                     "an unknown working set must set no wired limit")
+        XCTAssertEqual(MetalBudget.wiredLimit(workingSet: 1000, fraction: 0.9), 900)
+    }
+
+    #if os(macOS)
+    func testDesktopStillPinsNinetyPercent() {
+        XCTAssertEqual(MetalBudget.defaultPinFraction, 0.9,
+                       "macOS behaviour must be unchanged")
+    }
+    #else
+    func testConstrainedPlatformPinsNothingByDefault() {
+        XCTAssertEqual(MetalBudget.defaultPinFraction, 0.0)
+    }
+    #endif
+
+    // MARK: - MLX errors are survivable (#479 hardening)
+
+    /// mlx-swift's default handler calls `fatalError`, so any MLX failure
+    /// took the host process with it. Transcription must degrade to a
+    /// diagnostic string instead.
+    func testMLXErrorsBecomeADiagnosticStringNotAProcessKill() {
+        struct Boom: Error, LocalizedError {
+            var errorDescription: String? { "simulated MLX failure" }
+        }
+
+        XCTAssertEqual(
+            Qwen3ASRModel.catchingMLXErrors { "transcript" },
+            "transcript",
+            "the guard must be transparent when nothing fails")
+
+        let result = Qwen3ASRModel.catchingMLXErrors { throw Boom() }
+        XCTAssertTrue(result.hasPrefix("[Qwen3ASR MLX error:"),
+                      "a failure must surface as a diagnostic, got: \(result)")
+        XCTAssertTrue(result.contains("simulated MLX failure"),
+                      "the diagnostic must carry the underlying reason")
+    }
 
     // MARK: - cacheLimitForLarge
 


### PR DESCRIPTION
Split out of #481 so the verified Float16 fix isn't gated on this.

**This is hardening, not a proven fix.** #479 has no confirmed root cause and does not reproduce outside the reporter's device (A19 Pro, iOS 27 beta). The issue stays open. Each change below stands on its own merits; they are also the plausible contributors found while investigating.

## Changes

**Wired memory is now a macOS-only policy.** `MetalBudget.pinMemory()` wired 90% of `recommendedMaxWorkingSetSize` on every platform. That number describes the *device's* GPU budget; what terminates an app on iOS is its own jetsam limit, which is far smaller and treats wired pages as non-reclaimable. Pinning 90% of the device working set on a phone asks the OS to hold memory it may need back to keep the app alive. macOS is byte-identical (still 0.9); iOS now pins nothing by default, and a caller that wants it can still pass a fraction.

**The MLX cache limit is capped for every variant on iOS**, not just the 1.7B. MLX's default tracks the device's recommended working set, so the 0.6B — the model in the report — had no ceiling at all. The bound reuses the 1.7B formula: a ceiling where there was none, not a figure tuned against device telemetry.

**MLX failures no longer kill the process.** mlx-swift's default error handler calls `fatalError`, so any MLX error terminated the host app with no way to intervene — which is why wrapping the call in `withError` was the only thing that helped the reporter. Both public `transcribe` entry points now degrade to a `[Qwen3ASR MLX error: …]` string, the convention `CoreMLASRModel` already uses. Their bodies moved into private methods so the entry points are nothing but the guard.

**Drops a redundant `asType(.float32)`** in `pickNextToken`'s slow path. `asArray(Float.self)` already casts when the dtype differs, so that line allocated a second full-vocab array (151,936 floats, ~608 KB) per generated token and copied it again.

## What reviewers should weigh

Three judgement calls, stated plainly:

1. **`MetalBudget` is cross-module.** It lives in `MLXCommon`, so the pinning change also affects PersonaPlex, CosyVoice, Qwen3TTS and OmnilingualASR. macOS is unchanged; on iOS those modules now pin nothing. I believe that's right, but it is unverified on device and is scope beyond the title.
2. **`catchingMLXErrors` changes the consumer contract.** `transcribe` used to crash on an MLX error; it now returns an error string. A caller doing `if !text.isEmpty { save(text) }` would persist that string where it previously crashed. Deliberate — a process kill is not "loud failure", it is an unusable library — but it is a contract change.
3. **The iOS cache cap is a blind bet.** Capping the 0.6B's MLX cache could increase allocator churn and slow inference on device. Nobody has measured it.

## Not addressed

The slow path still pulls the full vocabulary to CPU once per token. Masking on-device would remove that, but it changes decoding and belongs behind its own quality gate.

## Tests

New unit tests for all three policies: the platform split for wired pinning (pure function, so both branches are testable from either platform), the cache ceiling across model size × platform, and that an MLX failure becomes a diagnostic string rather than a process kill.

`testGreedyDecodeMatchesSnapshot` confirms the `asType` removal is byte-identical output, and both no-repeat-n-gram E2E cases — the decode path in the crash backtrace — pass.

Full package gate: **1519 tests, 0 failures.**
